### PR TITLE
Add check for non-empty text to fix runtime error

### DIFF
--- a/PlusRemote/PlusRemote.py
+++ b/PlusRemote/PlusRemote.py
@@ -973,7 +973,8 @@ class PlusRemoteWidget(ScriptedLoadableModuleWidget):
     if command.GetResponseMessage():
       statusText = statusText + command.GetResponseMessage()
     else:
-      statusText = statusText + command.GetResponseText()
+      if command.GetResponseText():
+        statusText = statusText + command.GetResponseText()
     self.replyBox.setPlainText(statusText)
 
   def onGetCaptureDeviceCommandResponseReceived(self, command, q):


### PR DESCRIPTION
This issue caused runtime error while reconstructing prostate phantom dataset.

On a related note: after fixing this issue, the operation times out before getting the reconstructed volume back from the server. Should the timeout parameter be configurable? Not sure if it has any negative consequences, since even after the timeout the reconstructed volume is received in Slicer when ready.