### PR TITLE
Add compute normals filter

### DIFF
--- a/MarkupsToModel/MRML/vtkMRMLMarkupsToModelNode.cxx
+++ b/MarkupsToModel/MRML/vtkMRMLMarkupsToModelNode.cxx
@@ -54,8 +54,7 @@ vtkMRMLMarkupsToModelNode::vtkMRMLMarkupsToModelNode()
 
   this->AutoUpdateOutput=true;
   this->CleanMarkups=true;
-  this->ConvexHull=true;
-  this->ButterflySubdivision=true;
+  this->SmoothingType = 0;
   this->DelaunayAlpha=0.0;
   this->TubeRadius=1.0;
   this->ModelType = 0;
@@ -449,6 +448,19 @@ const char* vtkMRMLMarkupsToModelNode::GetInterpolationTypeAsString(int id)
   }
 }
 
+const char* vtkMRMLMarkupsToModelNode::GetSmoothingTypeAsString(int id)
+{
+  switch(id)
+  {
+  case NoFilter: return "noFilter";
+  case NormalsFilter: return "normalsFilter";
+  case ButterflyFilter: return "butterflyilter";
+  default:
+    // invalid id
+    return "";
+  }
+}
+
 int vtkMRMLMarkupsToModelNode::GetModelTypeFromString(const char* name)
 {
   if (name == NULL)
@@ -478,6 +490,25 @@ int vtkMRMLMarkupsToModelNode::GetInterpolationTypeFromString(const char* name)
   for (int i=0; i < InterpolationType_Last; i++)
   {
     if (strcmp(name, GetInterpolationTypeAsString(i)) == 0)
+    {
+      // found a matching name
+      return i;
+    }
+  }
+  // unknown name
+  return -1;
+}
+
+int vtkMRMLMarkupsToModelNode::GetSmoothingTypeFromString(const char* name)
+{
+  if (name == NULL)
+  {
+    // invalid name
+    return -1;
+  }
+  for (int i=0; i < SmoothingType_Last; i++)
+  {
+    if (strcmp(name, GetSmoothingTypeAsString(i)) == 0)
     {
       // found a matching name
       return i;

--- a/MarkupsToModel/MRML/vtkMRMLMarkupsToModelNode.h
+++ b/MarkupsToModel/MRML/vtkMRMLMarkupsToModelNode.h
@@ -80,7 +80,6 @@ public:
     ModelType_Last // insert valid types above this line
   };
 
-
   enum InterpolationType
   {
     Linear =0,
@@ -88,6 +87,14 @@ public:
     HermiteSpline,
     KochanekSpline,
     InterpolationType_Last // insert valid types above this line
+  };
+
+  enum SmoothingType
+  {
+    NoFilter = 0,
+    NormalsFilter,
+    ButterflyFilter,
+    SmoothingType_Last // insert valid types above this line
   };
   
   vtkTypeMacro( vtkMRMLMarkupsToModelNode, vtkMRMLNode );
@@ -125,6 +132,8 @@ public:
   vtkSetMacro( ModelType, int );
   vtkGetMacro( InterpolationType, int );
   vtkSetMacro( InterpolationType, int );
+  vtkGetMacro( SmoothingType, int );
+  vtkSetMacro( SmoothingType, int );
   vtkGetMacro( NumberOfIntermediatePoints, int );
   vtkSetMacro( NumberOfIntermediatePoints, int );
   
@@ -161,8 +170,10 @@ public:
   // Convert between model and interpolation types IDs and names.
   const char* GetModelTypeAsString(int id);
   const char* GetInterpolationTypeAsString(int id);
+  const char* GetSmoothingTypeAsString(int id);
   int GetModelTypeFromString(const char* name);
   int GetInterpolationTypeFromString(const char* name);
+  int GetSmoothingTypeFromString(const char* name);
 
   /// Gets the specified tool watched from the tools' list
   vtkMRMLMarkupsFiducialNode * GetMarkupsNode();
@@ -203,6 +214,7 @@ private:
   std::string ModelNodeID;
   int ModelType;
   int InterpolationType;
+  int SmoothingType;
   int NumberOfIntermediatePoints;
   bool AutoUpdateOutput;
   bool CleanMarkups;

--- a/MarkupsToModel/Resources/UI/qSlicerMarkupsToModelModuleWidget.ui
+++ b/MarkupsToModel/Resources/UI/qSlicerMarkupsToModelModuleWidget.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
-    <height>789</height>
+    <width>505</width>
+    <height>717</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,25 +18,26 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="qMRMLNodeComboBox" name="ModuleNodeComboBox" native="true">
+    <widget class="qMRMLNodeComboBox" name="ModuleNodeComboBox">
      <property name="enabled">
       <bool>true</bool>
      </property>
-     <property name="nodeTypes" stdset="0">
+     <property name="nodeTypes">
       <stringlist>
        <string>vtkMRMLMarkupsToModelNode</string>
       </stringlist>
      </property>
-     <property name="renameEnabled" stdset="0">
+     <property name="renameEnabled">
       <bool>true</bool>
      </property>
-     <property name="selectNodeUponCreation" stdset="0">
+     <property name="selectNodeUponCreation">
       <bool>true</bool>
      </property>
+     <zorder></zorder>
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="InputsCTKCollapsibleButton" native="true">
+    <widget class="ctkCollapsibleButton" name="InputsCTKCollapsibleButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -49,7 +50,7 @@
        <height>250</height>
       </size>
      </property>
-     <property name="text" stdset="0">
+     <property name="text">
       <string>Inputs</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -65,31 +66,31 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="qMRMLNodeComboBox" name="MarkupsNodeComboBox" native="true">
+           <widget class="qMRMLNodeComboBox" name="MarkupsNodeComboBox">
             <property name="enabled">
              <bool>true</bool>
             </property>
-            <property name="nodeTypes" stdset="0">
+            <property name="nodeTypes">
              <stringlist>
               <string>vtkMRMLMarkupsFiducialNode</string>
              </stringlist>
             </property>
-            <property name="baseName" stdset="0">
+            <property name="baseName">
              <string>M</string>
             </property>
-            <property name="noneEnabled" stdset="0">
+            <property name="noneEnabled">
              <bool>false</bool>
             </property>
-            <property name="addEnabled" stdset="0">
+            <property name="addEnabled">
              <bool>true</bool>
             </property>
-            <property name="removeEnabled" stdset="0">
+            <property name="removeEnabled">
              <bool>true</bool>
             </property>
-            <property name="editEnabled" stdset="0">
+            <property name="editEnabled">
              <bool>false</bool>
             </property>
-            <property name="renameEnabled" stdset="0">
+            <property name="renameEnabled">
              <bool>true</bool>
             </property>
            </widget>
@@ -161,7 +162,7 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="OutputCTKCollapsibleButton" native="true">
+    <widget class="ctkCollapsibleButton" name="OutputCTKCollapsibleButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -180,7 +181,7 @@
        <height>250</height>
       </size>
      </property>
-     <property name="text" stdset="0">
+     <property name="text">
       <string>Output</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_38">
@@ -189,25 +190,25 @@
         <item>
          <layout class="QGridLayout" name="OutputGridLayout">
           <item row="1" column="1">
-           <widget class="qMRMLNodeComboBox" name="ModelNodeComboBox" native="true">
+           <widget class="qMRMLNodeComboBox" name="ModelNodeComboBox">
             <property name="enabled">
              <bool>true</bool>
             </property>
-            <property name="nodeTypes" stdset="0">
+            <property name="nodeTypes">
              <stringlist>
               <string>vtkMRMLModelNode</string>
              </stringlist>
             </property>
-            <property name="noneEnabled" stdset="0">
+            <property name="noneEnabled">
              <bool>true</bool>
             </property>
-            <property name="addEnabled" stdset="0">
+            <property name="addEnabled">
              <bool>true</bool>
             </property>
-            <property name="removeEnabled" stdset="0">
+            <property name="removeEnabled">
              <bool>true</bool>
             </property>
-            <property name="renameEnabled" stdset="0">
+            <property name="renameEnabled">
              <bool>true</bool>
             </property>
            </widget>
@@ -338,11 +339,373 @@
         </item>
        </layout>
       </item>
+      <item>
+       <widget class="QCheckBox" name="CleanMarkupsCheckBox">
+        <property name="toolTip">
+         <string extracomment="It will merge duplicate  points.  Duplicate points are the ones closer than tolerance distance. The tolerance distance is 1% diagonal size bounding box of total points."/>
+        </property>
+        <property name="text">
+         <string>Clean duplicated markups</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="DisplayCTKCollapsibleButton" native="true">
+    <widget class="QTabWidget" name="ModeTab">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="ClosedSurfaceParameters">
+      <attribute name="title">
+       <string>Closed surface parameters</string>
+      </attribute>
+      <widget class="QGroupBox" name="SmoothingFilterGroupBox">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>10</y>
+         <width>471</width>
+         <height>90</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>90</height>
+        </size>
+       </property>
+       <property name="title">
+        <string>Smoothing filter</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <widget class="QRadioButton" name="NoFilterRadioButton">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>20</y>
+          <width>71</width>
+          <height>17</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>None</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+       <widget class="QRadioButton" name="ButterflyFilterRadioButton">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>60</y>
+          <width>171</width>
+          <height>17</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Butterfly subdivision</string>
+        </property>
+       </widget>
+       <widget class="QRadioButton" name="NormalsFilterRadioButton">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>40</y>
+          <width>161</width>
+          <height>17</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Compute normals</string>
+        </property>
+       </widget>
+       <widget class="QCheckBox" name="ConvexHullCheckBox">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="geometry">
+         <rect>
+          <x>260</x>
+          <y>20</y>
+          <width>111</width>
+          <height>22</height>
+         </rect>
+        </property>
+        <property name="toolTip">
+         <string extracomment="Create a convex hull around the model to remove self-intersection."/>
+        </property>
+        <property name="text">
+         <string>Convex hull</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+       <widget class="QLabel" name="DelaunayAlphaLabel">
+        <property name="geometry">
+         <rect>
+          <x>260</x>
+          <y>40</y>
+          <width>111</width>
+          <height>31</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Delaunay alpha</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+       <widget class="QDoubleSpinBox" name="DelaunayAlphaDoubleSpinBox">
+        <property name="geometry">
+         <rect>
+          <x>380</x>
+          <y>40</y>
+          <width>61</width>
+          <height>27</height>
+         </rect>
+        </property>
+        <property name="value">
+         <double>0.000000000000000</double>
+        </property>
+       </widget>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="CurveParameters">
+      <attribute name="title">
+       <string>Curve parameters</string>
+      </attribute>
+      <widget class="QWidget" name="horizontalLayoutWidget_2">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>351</width>
+         <height>162</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetNoConstraint</enum>
+        </property>
+        <item>
+         <widget class="QGroupBox" name="CurveInterpolationGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>100</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>130</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Interpolation</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <widget class="QRadioButton" name="LinearInterpolationButton">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>20</y>
+             <width>82</width>
+             <height>17</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>Linear</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+          <widget class="QRadioButton" name="CardinalInterpolationRadioButton">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>50</y>
+             <width>141</width>
+             <height>17</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>Cardinal Spline</string>
+           </property>
+          </widget>
+          <widget class="QRadioButton" name="KochanekInterpolationRadioButton">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>80</y>
+             <width>141</width>
+             <height>17</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>Kochanek Spline</string>
+           </property>
+          </widget>
+         </widget>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="3" column="0">
+           <widget class="QLabel" name="KochanekTensionLabel">
+            <property name="text">
+             <string>Tension</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="KochanekContinuityLabel">
+            <property name="text">
+             <string>Continuity</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="KochanekBiasLabel">
+            <property name="text">
+             <string>Bias</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="KochanekBiasDoubleSpinBox">
+            <property name="minimum">
+             <double>-1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="KochanekTensionDoubleSpinBox">
+            <property name="minimum">
+             <double>-1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="KochanekContinuityDoubleSpinBox">
+            <property name="minimum">
+             <double>-1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="TubeRadiusLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Tube radius</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="TubeRadiusDoubleSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_4"/>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="DisplayCTKCollapsibleButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -355,10 +718,10 @@
        <height>120</height>
       </size>
      </property>
-     <property name="text" stdset="0">
+     <property name="text">
       <string>Display</string>
      </property>
-     <property name="collapsed" stdset="0">
+     <property name="collapsed">
       <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -400,17 +763,17 @@
            </widget>
           </item>
           <item>
-           <widget class="ctkSliderWidget" name="OutputOpacitySlider" native="true">
-            <property name="singleStep" stdset="0">
+           <widget class="ctkSliderWidget" name="OutputOpacitySlider">
+            <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
-            <property name="pageStep" stdset="0">
+            <property name="pageStep">
              <double>0.100000000000000</double>
             </property>
-            <property name="maximum" stdset="0">
+            <property name="maximum">
              <double>1.000000000000000</double>
             </property>
-            <property name="value" stdset="0">
+            <property name="value">
              <double>1.000000000000000</double>
             </property>
            </widget>
@@ -430,17 +793,17 @@
            </widget>
           </item>
           <item>
-           <widget class="ctkSliderWidget" name="TextScaleSlider" native="true">
+           <widget class="ctkSliderWidget" name="TextScaleSlider">
             <property name="maximumSize">
              <size>
               <width>130</width>
               <height>80</height>
              </size>
             </property>
-            <property name="maximum" stdset="0">
+            <property name="maximum">
              <double>20.000000000000000</double>
             </property>
-            <property name="value" stdset="0">
+            <property name="value">
              <double>4.500000000000000</double>
             </property>
            </widget>
@@ -471,326 +834,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="AdvancedConversionParametersCTKCollapsibleButton" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>350</height>
-      </size>
-     </property>
-     <property name="text" stdset="0">
-      <string>Advance conversion parameters</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_39">
-      <item>
-       <widget class="QCheckBox" name="CleanMarkupsCheckBox">
-        <property name="toolTip">
-         <string extracomment="It will merge duplicate  points.  Duplicate points are the ones closer than tolerance distance. The tolerance distance is 1% diagonal size bounding box of total points."/>
-        </property>
-        <property name="text">
-         <string>Clean duplicated markups</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="widget" native="true">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>180</height>
-         </size>
-        </property>
-        <widget class="QWidget" name="horizontalLayoutWidget">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>396</width>
-           <height>29</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QCheckBox" name="ButterflySubdivisionCheckBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Butterfly subdivision filter</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="DelaunayAlphaLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Delaunay alpha</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDoubleSpinBox" name="DelaunayAlphaDoubleSpinBox">
-            <property name="value">
-             <double>0.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="horizontalLayoutWidget_2">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>60</y>
-           <width>351</width>
-           <height>162</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="sizeConstraint">
-           <enum>QLayout::SetNoConstraint</enum>
-          </property>
-          <item>
-           <widget class="QGroupBox" name="CurveInterpolationGroupBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>100</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>130</height>
-             </size>
-            </property>
-            <property name="title">
-             <string>Interpolation</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-            </property>
-            <widget class="QRadioButton" name="LinearInterpolationButton">
-             <property name="geometry">
-              <rect>
-               <x>10</x>
-               <y>20</y>
-               <width>82</width>
-               <height>17</height>
-              </rect>
-             </property>
-             <property name="text">
-              <string>Linear</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-            <widget class="QRadioButton" name="CardinalInterpolationRadioButton">
-             <property name="geometry">
-              <rect>
-               <x>10</x>
-               <y>50</y>
-               <width>91</width>
-               <height>17</height>
-              </rect>
-             </property>
-             <property name="text">
-              <string>Cardinal Spline</string>
-             </property>
-            </widget>
-            <widget class="QRadioButton" name="KochanekInterpolationRadioButton">
-             <property name="geometry">
-              <rect>
-               <x>10</x>
-               <y>80</y>
-               <width>101</width>
-               <height>17</height>
-              </rect>
-             </property>
-             <property name="text">
-              <string>Kochanek Spline</string>
-             </property>
-            </widget>
-           </widget>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="gridLayout">
-            <item row="3" column="0">
-             <widget class="QLabel" name="KochanekTensionLabel">
-              <property name="text">
-               <string>Tension</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="KochanekContinuityLabel">
-              <property name="text">
-               <string>Continuity</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="KochanekBiasLabel">
-              <property name="text">
-               <string>Bias</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QDoubleSpinBox" name="KochanekBiasDoubleSpinBox">
-              <property name="minimum">
-               <double>-1.000000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>0.100000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QDoubleSpinBox" name="KochanekTensionDoubleSpinBox">
-              <property name="minimum">
-               <double>-1.000000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>0.100000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QDoubleSpinBox" name="KochanekContinuityDoubleSpinBox">
-              <property name="minimum">
-               <double>-1.000000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>0.100000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="TubeRadiusLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Tube radius</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QDoubleSpinBox" name="TubeRadiusDoubleSpinBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="value">
-               <double>1.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_4"/>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QCheckBox" name="ConvexHullCheckBox">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>30</y>
-           <width>379</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string extracomment="Create a convex hull around the model to remove self-intersection."/>
-         </property>
-         <property name="text">
-          <string>Convex hull</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/MarkupsToModel/qSlicerMarkupsToModelModuleWidget.cxx
+++ b/MarkupsToModel/qSlicerMarkupsToModelModuleWidget.cxx
@@ -17,6 +17,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QTabWidget>
 
 #include "qSlicerApplication.h"
 
@@ -78,11 +79,8 @@ qSlicerMarkupsToModelModuleWidget::~qSlicerMarkupsToModelModuleWidget()
   Q_D( qSlicerMarkupsToModelModuleWidget );
   disconnect( d->ModuleNodeComboBox, SIGNAL( currentNodeChanged( vtkMRMLNode* ) ), this, SLOT( onMarkupsToModelModuleNodeChanged() ) );
   disconnect( d->ModuleNodeComboBox, SIGNAL( nodeAddedByUser( vtkMRMLNode* ) ), this, SLOT( onMarkupsToModelModuleNodeAddedByUser( vtkMRMLNode* ) ) );
-  //disconnect( d->ModuleNodeComboBox, SIGNAL( nodeAboutToBeRemoved( vtkMRMLNode* ) ), this, SLOT( onMarkupsToModelModuleNodeAboutToBeRemoved( vtkMRMLNode* ) ) );
 
   disconnect( d->ModelNodeComboBox, SIGNAL( currentNodeChanged( vtkMRMLNode* ) ), this, SLOT( onModelNodeChanged() ) );
-  //connect( d->ModelNodeComboBox, SIGNAL(nodeAddedByUser(vtkMRMLNode* )), this, SLOT(onModelNodeAddedByUser(vtkMRMLNode* ) ) );
-  //connect( d->ModelNodeComboBox, SIGNAL(nodeAboutToBeRemoved(vtkMRMLNode* )), this, SLOT(onMarkupsToModelModelNodeAboutToBeRemoved(vtkMRMLNode* ) ) );
 
   disconnect( d->MarkupsNodeComboBox, SIGNAL( currentNodeChanged( vtkMRMLNode* ) ), this, SLOT( onCurrentMarkupsNodeChanged() ) );
   disconnect( d->MarkupsNodeComboBox, SIGNAL( nodeAboutToBeEdited( vtkMRMLNode* ) ), this, SLOT( onNodeAboutToBeEdited( vtkMRMLNode* ) ) );
@@ -94,15 +92,18 @@ qSlicerMarkupsToModelModuleWidget::~qSlicerMarkupsToModelModuleWidget()
 
   disconnect( d->AutoUpdateOutputCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onAutoUpdateOutputToggled( bool ) ) );
 
-  disconnect( d->ButterflySubdivisionCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onButterflySubdivisionToggled( bool ) ) );
-  disconnect( d->ConvexHullCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onConvexHullToggled( bool ) ) );
-
   disconnect( d->CleanMarkupsCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onCleanMarkupsToggled( bool ) ) );
   disconnect( d->ClosedSurfaceRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onModeGroupBoxClicked( bool ) ) );
   disconnect( d->CurveRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onModeGroupBoxClicked( bool ) ) );
-  disconnect( d->DelaunayAlphaDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onDelaunayAlphaDoubleChanged( double ) ) );
-  disconnect( d->TubeRadiusDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onTubeRadiusDoubleChanged( double ) ) );
 
+  disconnect( d->NoFilterRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onSmoothingFilterGroupBoxClicked( bool ) ) );
+  disconnect( d->NormalsFilterRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onSmoothingFilterGroupBoxClicked( bool ) ) );
+  disconnect( d->ButterflyFilterRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onSmoothingFilterGroupBoxClicked( bool ) ) );
+
+  disconnect( d->DelaunayAlphaDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onDelaunayAlphaDoubleChanged( double ) ) );
+  disconnect( d->ConvexHullCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onConvexHullToggled( bool ) ) );
+
+  disconnect( d->TubeRadiusDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onTubeRadiusDoubleChanged( double ) ) );
   disconnect( d->KochanekBiasDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onKochanekBiasDoubleChanged( double ) ) );
   disconnect( d->KochanekContinuityDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onKochanekContinuityDoubleChanged( double ) ) );
   disconnect( d->KochanekTensionDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onKochanekTensionDoubleChanged( double ) ) );
@@ -158,11 +159,8 @@ void qSlicerMarkupsToModelModuleWidget::setup()
 
   connect( d->ModuleNodeComboBox, SIGNAL( currentNodeChanged( vtkMRMLNode* ) ), this, SLOT( onMarkupsToModelModuleNodeChanged() ) );
   connect( d->ModuleNodeComboBox, SIGNAL( nodeAddedByUser( vtkMRMLNode* ) ), this, SLOT( onMarkupsToModelModuleNodeAddedByUser( vtkMRMLNode* ) ) );
-  //connect( d->ModuleNodeComboBox, SIGNAL( nodeAboutToBeRemoved( vtkMRMLNode* ) ), this, SLOT( onMarkupsToModelModuleNodeAboutToBeRemoved( vtkMRMLNode* ) ) );
 
   connect( d->ModelNodeComboBox, SIGNAL( currentNodeChanged( vtkMRMLNode* ) ), this, SLOT( onModelNodeChanged() ) );
-  //connect( d->ModelNodeComboBox, SIGNAL(nodeAddedByUser(vtkMRMLNode* )), this, SLOT(onModelNodeAddedByUser(vtkMRMLNode* ) ) );
-  //connect( d->ModelNodeComboBox, SIGNAL(nodeAboutToBeRemoved(vtkMRMLNode* )), this, SLOT(onMarkupsToModelModelNodeAboutToBeRemoved(vtkMRMLNode* ) ) );
 
   connect( d->MarkupsNodeComboBox, SIGNAL( currentNodeChanged( vtkMRMLNode* ) ), this, SLOT( onCurrentMarkupsNodeChanged() ) );
   connect( d->MarkupsNodeComboBox, SIGNAL( nodeAboutToBeEdited( vtkMRMLNode* ) ), this, SLOT( onNodeAboutToBeEdited( vtkMRMLNode* ) ) );
@@ -176,8 +174,6 @@ void qSlicerMarkupsToModelModuleWidget::setup()
   d->PlacePushButton->setIcon( QIcon( ":/Icons/MarkupsMouseModePlace.png" ) );
 
   connect( d->AutoUpdateOutputCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onAutoUpdateOutputToggled( bool ) ) );
-
-  connect( d->ButterflySubdivisionCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onButterflySubdivisionToggled( bool ) ) );
   connect( d->ConvexHullCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onConvexHullToggled( bool ) ) );
 
   connect( d->CleanMarkupsCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( onCleanMarkupsToggled( bool ) ) );
@@ -186,6 +182,11 @@ void qSlicerMarkupsToModelModuleWidget::setup()
   
   connect( d->ClosedSurfaceRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onModeGroupBoxClicked( bool ) ) );
   connect( d->CurveRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onModeGroupBoxClicked( bool ) ) );
+
+  connect( d->NoFilterRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onSmoothingFilterGroupBoxClicked( bool ) ) );
+  connect( d->NormalsFilterRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onSmoothingFilterGroupBoxClicked( bool ) ) );
+  connect( d->ButterflyFilterRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onSmoothingFilterGroupBoxClicked( bool ) ) );
+
   connect( d->DelaunayAlphaDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onDelaunayAlphaDoubleChanged( double ) ) );
   connect( d->TubeRadiusDoubleSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( onTubeRadiusDoubleChanged( double ) ) );
   
@@ -238,6 +239,7 @@ void qSlicerMarkupsToModelModuleWidget::enter()
     d->ModuleNodeComboBox->setCurrentNodeID( node->GetID() );
   }
   onModeGroupBoxClicked( true );
+  onSmoothingFilterGroupBoxClicked( true );
 
   this->previouslyPersistent = qSlicerApplication::application()->applicationLogic()->GetInteractionNode()->GetPlaceModePersistence();
   qSlicerApplication::application()->applicationLogic()->GetInteractionNode()->SetPlaceModePersistence(1);
@@ -288,13 +290,11 @@ void qSlicerMarkupsToModelModuleWidget::onSceneImportedEvent()
   qCritical( "PERRAS" );
   this->enter();
   this->updateFromMRMLNode();
-  //this->updateWidget();
 }
 
 //-----------------------------------------------------------------------------
 void qSlicerMarkupsToModelModuleWidget::updateWidget()
 {
-  //qCritical( "HOLAS" );
   Q_D( qSlicerMarkupsToModelModuleWidget );
   vtkMRMLNode* currentModuleNode = d->ModuleNodeComboBox->currentNode();
   if ( currentModuleNode == NULL )
@@ -319,7 +319,6 @@ void qSlicerMarkupsToModelModuleWidget::updateWidget()
     d->DeleteLastPushButton->setChecked( Qt::Unchecked );
     d->UpdateOutputModelPushButton->setChecked( Qt::Unchecked );
     // This will ensure that we refresh the widget next time we move to a non-null widget ( since there is guaranteed to be a modified status of larger than zero )
-    //return;
     d->DeleteAllPushButton->setEnabled( false );
     d->DeleteLastPushButton->setEnabled( false );
     d->UpdateOutputModelPushButton->setEnabled( false );
@@ -371,7 +370,7 @@ void qSlicerMarkupsToModelModuleWidget::updateFromMRMLNode()
   }
   d->MarkupsNodeComboBox->setEnabled( true );
 
-  if ( /*d->ModelNodeComboBox->currentNode() == 0 &&*/ MarkupsToModelNode->GetMarkupsNode() != NULL )
+  if ( MarkupsToModelNode->GetMarkupsNode() != NULL )
   {
     d->MarkupsNodeComboBox->setCurrentNodeID( MarkupsToModelNode->GetMarkupsNode()->GetID() );
   }
@@ -380,10 +379,9 @@ void qSlicerMarkupsToModelModuleWidget::updateFromMRMLNode()
     d->MarkupsNodeComboBox->setCurrentNodeIndex( 0 );
   }
 
-  if ( /*d->ModelNodeComboBox->currentNode() == 0 && */MarkupsToModelNode->GetModelNode() != NULL )
+  if ( MarkupsToModelNode->GetModelNode() != NULL )
   {
     d->ModelNodeComboBox->setCurrentNodeID( MarkupsToModelNode->GetModelNode()->GetID() );
-    //qCritical( "Model not null" );
   }
   else
   {
@@ -405,10 +403,30 @@ void qSlicerMarkupsToModelModuleWidget::updateFromMRMLNode()
   switch( MarkupsToModelNode->GetModelType() )
   {
   case vtkMRMLMarkupsToModelNode::ClosedSurface: 
-    d->ClosedSurfaceRadioButton->setChecked( 1 ); break;
-    d->ButterflySubdivisionCheckBox->setChecked( MarkupsToModelNode->GetButterflySubdivision() );
-    d->DelaunayAlphaDoubleSpinBox->setValue( MarkupsToModelNode->GetDelaunayAlpha() );
-    d->ConvexHullCheckBox->setChecked( MarkupsToModelNode->GetConvexHull() );
+    d->ClosedSurfaceRadioButton->setChecked( 1 );
+    switch( MarkupsToModelNode->GetSmoothingType() )
+    {
+    case vtkMRMLMarkupsToModelNode::NoFilter:
+      d->NoFilterRadioButton->setChecked( 1 );
+      d->NormalsFilterRadioButton->setChecked( 0 );
+      d->ButterflyFilterRadioButton->setChecked( 0 );
+      d->ConvexHullCheckBox->setChecked( 0 );
+      break;
+    case vtkMRMLMarkupsToModelNode::NormalsFilter:
+      d->NoFilterRadioButton->setChecked( 0 );
+      d->NormalsFilterRadioButton->setChecked( 1 );
+      d->ButterflyFilterRadioButton->setChecked( 0 );
+      d->ConvexHullCheckBox->setChecked( 0 );
+      break;
+    case vtkMRMLMarkupsToModelNode::ButterflyFilter:
+      d->NoFilterRadioButton->setChecked( 0 );
+      d->NormalsFilterRadioButton->setChecked( 0 );
+      d->ButterflyFilterRadioButton->setChecked( 1 );
+      d->ConvexHullCheckBox->setChecked( 1 );
+      d->DelaunayAlphaDoubleSpinBox->setValue( MarkupsToModelNode->GetDelaunayAlpha() );
+      break;
+    }
+    break;
 
   case vtkMRMLMarkupsToModelNode::Curve: d->CurveRadioButton->setChecked( 1 );
     d->TubeRadiusDoubleSpinBox->setValue(MarkupsToModelNode->GetTubeRadius());
@@ -428,8 +446,6 @@ void qSlicerMarkupsToModelModuleWidget::updateFromMRMLNode()
 
   this->updateWidget();
 }
-
-
 
 
 //-----------------------------------------------------------------------------
@@ -463,27 +479,6 @@ void qSlicerMarkupsToModelModuleWidget::onModelNodeChanged()
 
   UpdateOutputModel();
 }
-
-////-----------------------------------------------------------------------------
-//void qSlicerMarkupsToModelModuleWidget::onModelNodeAddedByUser( vtkMRMLNode* nodeAdded )
-//{
-//  Q_D( qSlicerMarkupsToModelModuleWidget );
-//  if ( this->mrmlScene() == NULL )
-//  {
-//    qCritical() << "Invalid scene!";
-//    return;
-//  }
-//  // For convenience, select a default module.
-//  if( nodeAdded==NULL )
-//  {
-//    return;
-//  }
-//  vtkMRMLModelNode* ModelNodeAdded = vtkMRMLModelNode::SafeDownCast( nodeAdded );
-//  if( ModelNodeAdded==NULL )
-//  {
-//    return;
-//  }
-//}
 
 //-----------------------------------------------------------------------------
 void qSlicerMarkupsToModelModuleWidget::onMarkupsToModelModuleNodeChanged()
@@ -623,7 +618,6 @@ void qSlicerMarkupsToModelModuleWidget::onInterpolationBoxClicked( bool nana )
 void qSlicerMarkupsToModelModuleWidget::onModeGroupBoxClicked( bool nana )
 {
   Q_D( qSlicerMarkupsToModelModuleWidget );
-  //qCritical( "HOLAS" );
   vtkMRMLMarkupsToModelNode* markupsToModelModuleNode = vtkMRMLMarkupsToModelNode::SafeDownCast( d->ModuleNodeComboBox->currentNode() );
   if ( markupsToModelModuleNode == NULL )
   {
@@ -633,32 +627,12 @@ void qSlicerMarkupsToModelModuleWidget::onModeGroupBoxClicked( bool nana )
 
   if( d->ClosedSurfaceRadioButton->isChecked() )
   {
-    d->ButterflySubdivisionCheckBox->setVisible( true );
-    d->DelaunayAlphaLabel->setVisible( true );
-    d->DelaunayAlphaDoubleSpinBox->setVisible( true );
-    d->ConvexHullCheckBox->setVisible( true );
-
-    d->CurveInterpolationGroupBox->setVisible( false );
-    d->TubeRadiusLabel->setVisible( false );
-    d->TubeRadiusDoubleSpinBox->setVisible( false );
-    d->KochanekBiasLabel->setVisible( false );
-    d->KochanekBiasDoubleSpinBox->setVisible( false );
-    d->KochanekTensionLabel->setVisible( false );
-    d->KochanekTensionDoubleSpinBox->setVisible( false );
-    d->KochanekContinuityLabel->setVisible( false );
-    d->KochanekContinuityDoubleSpinBox->setVisible( false );
+    d->ModeTab->setCurrentIndex(0);
     markupsToModelModuleNode->SetModelType( vtkMRMLMarkupsToModelNode::ClosedSurface );
   }
   else
   {
-    d->ButterflySubdivisionCheckBox->setVisible( false );
-    d->DelaunayAlphaLabel->setVisible( false );
-    d->DelaunayAlphaDoubleSpinBox->setVisible( false );
-    d->ConvexHullCheckBox->setVisible( false );
-
-    d->CurveInterpolationGroupBox->setVisible( true );
-    d->TubeRadiusLabel->setVisible( true );
-    d->TubeRadiusDoubleSpinBox->setVisible( true );
+    d->ModeTab->setCurrentIndex(1);
     markupsToModelModuleNode->SetModelType( vtkMRMLMarkupsToModelNode::Curve );
 
     if(d->KochanekInterpolationRadioButton->isChecked())
@@ -678,6 +652,42 @@ void qSlicerMarkupsToModelModuleWidget::onModeGroupBoxClicked( bool nana )
       d->KochanekTensionDoubleSpinBox->setVisible( false );
       d->KochanekContinuityLabel->setVisible( false );
       d->KochanekContinuityDoubleSpinBox->setVisible( false );
+    }
+  }
+
+  UpdateOutputModel();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMarkupsToModelModuleWidget::onSmoothingFilterGroupBoxClicked( bool nana )
+{
+  Q_D( qSlicerMarkupsToModelModuleWidget );
+  vtkMRMLMarkupsToModelNode* markupsToModelModuleNode = vtkMRMLMarkupsToModelNode::SafeDownCast( d->ModuleNodeComboBox->currentNode() );
+  if ( markupsToModelModuleNode == NULL )
+  {
+    qCritical( "Conversion Mode changed with no module node selection" );
+    return;
+  }
+
+  if ( d->ButterflyFilterRadioButton->isChecked() )
+  {
+    d->ConvexHullCheckBox->setVisible( true );
+    d->DelaunayAlphaLabel->setVisible( true );
+    d->DelaunayAlphaDoubleSpinBox->setVisible( true );
+    markupsToModelModuleNode->SetSmoothingType( vtkMRMLMarkupsToModelNode::ButterflyFilter );
+  }
+  else
+  {
+    d->ConvexHullCheckBox->setVisible( false );
+    d->DelaunayAlphaLabel->setVisible( false );
+    d->DelaunayAlphaDoubleSpinBox->setVisible( false );
+    if (d->NormalsFilterRadioButton->isChecked() )
+    {
+      markupsToModelModuleNode->SetSmoothingType( vtkMRMLMarkupsToModelNode::NormalsFilter );
+    }
+    else
+    {
+      markupsToModelModuleNode->SetSmoothingType( vtkMRMLMarkupsToModelNode::NoFilter );
     }
   }
 
@@ -816,7 +826,6 @@ void qSlicerMarkupsToModelModuleWidget::onTextScaleChanged( double textScale )
   }
   vtkMRMLMarkupsDisplayNode * markupsDisplay = vtkMRMLMarkupsDisplayNode::SafeDownCast( markupsNode->GetDisplayNode() );
   markupsDisplay->SetTextScale(textScale);
-  //d->logic()->MarkupsLogic->SetDefaultMarkupsDisplayNodeTextScale( textScale );
 }
 
 
@@ -844,20 +853,6 @@ void qSlicerMarkupsToModelModuleWidget::onCleanMarkupsToggled( bool cleanMarkups
     return;
   }
   markupsToModelModuleNode->SetCleanMarkups( cleanMarkups );
-  UpdateOutputModel();
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerMarkupsToModelModuleWidget::onButterflySubdivisionToggled( bool butterflySubdivision )
-{
-  Q_D( qSlicerMarkupsToModelModuleWidget );
-  vtkMRMLMarkupsToModelNode* markupsToModelModuleNode = vtkMRMLMarkupsToModelNode::SafeDownCast( d->ModuleNodeComboBox->currentNode() );
-  if ( markupsToModelModuleNode == NULL )
-  {
-    qCritical( "Model node changed with no module node selection" );
-    return;
-  }
-  markupsToModelModuleNode->SetButterflySubdivision( butterflySubdivision );
   UpdateOutputModel();
 }
 
@@ -925,7 +920,6 @@ void qSlicerMarkupsToModelModuleWidget::onPlacePushButtonClicked()
   else
   {
     interactionNode->SetCurrentInteractionMode( vtkMRMLInteractionNode::Place );
-    // interactionNode->SetPlaceModePersistence( true ); // Use whatever persistence the user has already set
   }
 
   if ( currentMarkupsNode != NULL )

--- a/MarkupsToModel/qSlicerMarkupsToModelModuleWidget.h
+++ b/MarkupsToModel/qSlicerMarkupsToModelModuleWidget.h
@@ -70,6 +70,7 @@ public slots:
 
   void onInterpolationBoxClicked( bool nana );
   void onModeGroupBoxClicked( bool nana );
+  void onSmoothingFilterGroupBoxClicked( bool nana );
   void onOutputOpacityValueChanged( double outputTransparency );
   void onOutputColorChanged( QColor newColor );
   void onTubeRadiusDoubleChanged( double tubeRadius );
@@ -83,7 +84,6 @@ public slots:
   void onOutputIntersectionVisibilityToggled( bool outputIntersectionVisibility );
   void onCleanMarkupsToggled( bool cleanMarkups );
   void onAutoUpdateOutputToggled( bool autoUpdateOutput );
-  void onButterflySubdivisionToggled( bool butterflySubdivision );
   void onConvexHullToggled( bool convexHull );
 
 


### PR DESCRIPTION
Adds a new filter option that computes normals for the mesh. The different filter options are placed in a tabbed layout and selected with radio buttons instead of conflicting checkboxes. Basically this is just a new option, so that instead of the butterfly subdivision filter they can select this one, or neither.