### PR TITLE
Added Recording Always Enabled Parameter.

### DIFF
--- a/Guidelet/GuideletLib/UltraSound.py
+++ b/Guidelet/GuideletLib/UltraSound.py
@@ -29,7 +29,7 @@ class UltraSound(object):
 
   def onConnectorNodeDisconnected(self):
     self.freezeUltrasoundButton.setText('Un-freeze')
-    if self.guideletParent.parameterNode.GetParameter('RecordingAlwaysEnabled') == 'False':
+    if self.guideletParent.parameterNode.GetParameter('RecordingEnabledWhenConnectorNodeDisconnected') == 'False':
       self.startStopRecordingButton.setEnabled(False)
 
   def setupPanel(self, parentWidget):

--- a/Guidelet/GuideletLib/UltraSound.py
+++ b/Guidelet/GuideletLib/UltraSound.py
@@ -29,7 +29,8 @@ class UltraSound(object):
 
   def onConnectorNodeDisconnected(self):
     self.freezeUltrasoundButton.setText('Un-freeze')
-    self.startStopRecordingButton.setEnabled(False)
+    if self.guideletParent.parameterNode.GetParameter('RecordingAlwaysEnabled') == 'False':
+      self.startStopRecordingButton.setEnabled(False)
 
   def setupPanel(self, parentWidget):
     logging.debug('UltraSound.setupPanel')

--- a/Guidelet/GuideletLoadable.py
+++ b/Guidelet/GuideletLoadable.py
@@ -191,7 +191,7 @@ class GuideletLogic(ScriptedLoadableModuleLogic):
                    'RecordingFilenameExtension' : '.mhd',
                    'SavedScenesDirectory' : defaultSavePath,
                    'UltrasoundBrightnessControl' : 'Buttons',
-                   'RecordingAlwaysEnabled' : 'False',
+                   'RecordingEnabledWhenConnectorNodeDisconnected' : 'False',
                    }
     self.updateSettings(settingList, 'Default')
 

--- a/Guidelet/GuideletLoadable.py
+++ b/Guidelet/GuideletLoadable.py
@@ -190,7 +190,8 @@ class GuideletLogic(ScriptedLoadableModuleLogic):
                    'RecordingFilenamePrefix' : 'GuideletRecording-',
                    'RecordingFilenameExtension' : '.mhd',
                    'SavedScenesDirectory' : defaultSavePath,
-                   'UltrasoundBrightnessControl' : 'Buttons'
+                   'UltrasoundBrightnessControl' : 'Buttons',
+                   'RecordingAlwaysEnabled' : 'False',
                    }
     self.updateSettings(settingList, 'Default')
 


### PR DESCRIPTION
If set to True (False by default in Guidelet base) in the user's
guidelet parameters, the recording button will remain clickable even if
the plus connector is frozen.