### PR TITLE
Added PLUS Capture Device parameter and Wait Cursor to Guidelet Base.

### DIFF
--- a/Guidelet/GuideletLib/Guidelet.py
+++ b/Guidelet/GuideletLib/Guidelet.py
@@ -364,6 +364,7 @@ class Guidelet(object):
     #
     # save the mrml scene to a temp directory, then zip it
     #
+    qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
     node = self.logic.getParameterNode()
     sceneSaveDirectory = node.GetParameter('SavedScenesDirectory')
     sceneSaveDirectory = sceneSaveDirectory + "/" + self.logic.moduleName + "-" + time.strftime("%Y%m%d-%H%M%S")
@@ -376,6 +377,8 @@ class Guidelet(object):
       logging.info("Scene saved to: {0}".format(sceneSaveDirectory))
     else:
       logging.error("Scene saving failed")
+    qt.QApplication.restoreOverrideCursor()
+    slicer.util.showStatusMessage("Saved!", 2000)
 
   def onExitButtonClicked(self):
     mainwindow = slicer.util.mainWindow()

--- a/Guidelet/GuideletLib/UltraSound.py
+++ b/Guidelet/GuideletLib/UltraSound.py
@@ -8,7 +8,7 @@ class UltraSound(object):
 
   def __init__(self, guideletParent):
     self.guideletParent = guideletParent
-    self.captureDeviceName=self.guideletParent.parameterNode.GetParameter('PLUSCaptureDeviceName')
+    self.captureDeviceName = self.guideletParent.parameterNode.GetParameter('PLUSCaptureDeviceName')
     self.referenceToRas = None
 
     from PlusRemote import PlusRemoteLogic
@@ -229,7 +229,7 @@ class UltraSound(object):
       self.startStopRecordingButton.setText("  Stop Recording")
       self.startStopRecordingButton.setIcon(self.stopIcon)
       self.startStopRecordingButton.setToolTip("Recording is being started...")
-      if not self.captureDeviceName  == '':
+      if self.captureDeviceName  != '':
         # Important to save as .mhd because that does not require lengthy finalization (merging into a single file)
         recordPrefix = self.guideletParent.parameterNode.GetParameter('RecordingFilenamePrefix')
         recordExt = self.guideletParent.parameterNode.GetParameter('RecordingFilenameExtension')
@@ -245,7 +245,7 @@ class UltraSound(object):
       self.startStopRecordingButton.setText("  Start Recording")
       self.startStopRecordingButton.setIcon(self.recordIcon)
       self.startStopRecordingButton.setToolTip( "Recording is being stopped..." )
-      if not self.captureDeviceName  == '':  
+      if self.captureDeviceName  != '':  
         logging.info("Stopping recording")  
         self.plusRemoteLogic.cmdStopRecording.SetCommandAttribute('CaptureDeviceId', self.captureDeviceName)
         self.guideletParent.executeCommand(self.plusRemoteLogic.cmdStopRecording, self.recordingCommandCompleted)

--- a/Guidelet/GuideletLib/UltraSound.py
+++ b/Guidelet/GuideletLib/UltraSound.py
@@ -8,7 +8,7 @@ class UltraSound(object):
 
   def __init__(self, guideletParent):
     self.guideletParent = guideletParent
-    self.captureDeviceName='CaptureDevice'
+    self.captureDeviceName=self.guideletParent.parameterNode.GetParameter('PLUSCaptureDeviceName')
     self.referenceToRas = None
 
     from PlusRemote import PlusRemoteLogic
@@ -229,25 +229,26 @@ class UltraSound(object):
       self.startStopRecordingButton.setText("  Stop Recording")
       self.startStopRecordingButton.setIcon(self.stopIcon)
       self.startStopRecordingButton.setToolTip("Recording is being started...")
+      if not self.captureDeviceName  == '':
+        # Important to save as .mhd because that does not require lengthy finalization (merging into a single file)
+        recordPrefix = self.guideletParent.parameterNode.GetParameter('RecordingFilenamePrefix')
+        recordExt = self.guideletParent.parameterNode.GetParameter('RecordingFilenameExtension')
+        self.recordingFileName =  recordPrefix + time.strftime("%Y%m%d-%H%M%S") + recordExt
 
-      # Important to save as .mhd because that does not require lengthy finalization (merging into a single file)
-      recordPrefix = self.guideletParent.parameterNode.GetParameter('RecordingFilenamePrefix')
-      recordExt = self.guideletParent.parameterNode.GetParameter('RecordingFilenameExtension')
-      self.recordingFileName =  recordPrefix + time.strftime("%Y%m%d-%H%M%S") + recordExt
+        logging.info("Starting recording to: {0}".format(self.recordingFileName))
 
-      logging.info("Starting recording to: {0}".format(self.recordingFileName))
-
-      self.plusRemoteLogic.cmdStartRecording.SetCommandAttribute('CaptureDeviceId', self.captureDeviceName)
-      self.plusRemoteLogic.cmdStartRecording.SetCommandAttribute('OutputFilename', self.recordingFileName)
-      self.guideletParent.executeCommand(self.plusRemoteLogic.cmdStartRecording, self.recordingCommandCompleted)
+        self.plusRemoteLogic.cmdStartRecording.SetCommandAttribute('CaptureDeviceId', self.captureDeviceName)
+        self.plusRemoteLogic.cmdStartRecording.SetCommandAttribute('OutputFilename', self.recordingFileName)
+        self.guideletParent.executeCommand(self.plusRemoteLogic.cmdStartRecording, self.recordingCommandCompleted)
 
     else:
-      logging.info("Stopping recording")
       self.startStopRecordingButton.setText("  Start Recording")
       self.startStopRecordingButton.setIcon(self.recordIcon)
       self.startStopRecordingButton.setToolTip( "Recording is being stopped..." )
-      self.plusRemoteLogic.cmdStopRecording.SetCommandAttribute('CaptureDeviceId', self.captureDeviceName)
-      self.guideletParent.executeCommand(self.plusRemoteLogic.cmdStopRecording, self.recordingCommandCompleted)
+      if not self.captureDeviceName  == '':  
+        logging.info("Stopping recording")  
+        self.plusRemoteLogic.cmdStopRecording.SetCommandAttribute('CaptureDeviceId', self.captureDeviceName)
+        self.guideletParent.executeCommand(self.plusRemoteLogic.cmdStopRecording, self.recordingCommandCompleted)
 
   def onFreezeUltrasoundClicked(self):
     logging.debug('onFreezeUltrasoundClicked')

--- a/Guidelet/GuideletLoadable.py
+++ b/Guidelet/GuideletLoadable.py
@@ -192,6 +192,7 @@ class GuideletLogic(ScriptedLoadableModuleLogic):
                    'SavedScenesDirectory' : defaultSavePath,
                    'UltrasoundBrightnessControl' : 'Buttons',
                    'RecordingEnabledWhenConnectorNodeDisconnected' : 'False',
+                   'PLUSCaptureDeviceName' : 'CaptureDevice', # If '', no PLUS recordings are saved.
                    }
     self.updateSettings(settingList, 'Default')
 


### PR DESCRIPTION
This allows the option of setting the name for the capture device. If
set to '', PLUS will not record to file. This can be used to allow the
Sequences extension to handle saving of recordings within Slicer instead
of PLUS.