### PR TITLE
BUG: Fix bug in OpenIGTLink Remote causing Slicer to crash

### DIFF
--- a/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
+++ b/OpenIGTLinkRemote/Widgets/qSlicerOpenIGTLinkRemoteQueryWidget.cxx
@@ -349,7 +349,13 @@ void qSlicerOpenIGTLinkRemoteQueryWidget::querySelectedItem()
   {
     int topRowIndex = selectRange.at(selectionIndex).topRow();
     // Get the item identifier from the table
-    std::string dataId( d->remoteDataListTable->item(topRowIndex, 0)->text().toLatin1() );
+    QTableWidgetItem *selectedItem = d->remoteDataListTable->item(topRowIndex, 0);
+    if (!selectedItem)
+    {
+      qCritical() << Q_FUNC_INFO << " failed: selected item is empty";
+      continue;
+    }
+    std::string dataId( selectedItem->text().toLatin1() );
     switch (d->typeButtonGroup.checkedId()) 
     {
     case qSlicerOpenIGTLinkRemoteQueryWidgetPrivate::TYPE_IMAGE:
@@ -628,6 +634,7 @@ void qSlicerOpenIGTLinkRemoteQueryWidget::onQueryTypeChanged(int id)
 {
   Q_D(qSlicerOpenIGTLinkRemoteQueryWidget);
   d->remoteDataListTable->clearContents();
+  d->remoteDataListTable->setRowCount(0);
   QStringList list;
   switch(id)
   {


### PR DESCRIPTION
Changing the query data type when the list has been populated with items will cause the items in the list to become empty.
Selecting one of these empty items and clicking "Get selected items" will cause Slicer to crash.

Fix is two-fold:
- After query data type is changed, set the number of rows to zero, so that there are no empty items in the list.
- When attempting to get a selected item in querySelectedItem(), check to see if the item exists. If it does not, print an error message and skip the currently selected item.