### PR TITLE
Replaced usages of slicer.util.getNode in Guidelet

### DIFF
--- a/Guidelet/GuideletLib/Guidelet.py
+++ b/Guidelet/GuideletLib/Guidelet.py
@@ -39,7 +39,7 @@ class Guidelet(object):
 
   @staticmethod
   def showUltrasoundIn3dView(show):
-    redNode = slicer.util.getNode('vtkMRMLSliceNodeRed')
+    redNode = slicer.mrmlScene.GetNodeByID('vtkMRMLSliceNodeRed')
     if show:
       redNode.SetSliceVisible(1)
     else:

--- a/Guidelet/GuideletLib/UltraSound.py
+++ b/Guidelet/GuideletLib/UltraSound.py
@@ -132,7 +132,7 @@ class UltraSound(object):
     '''
 
     if self.referenceToRas is None or (self.referenceToRas and slicer.mrmlScene.GetNodeByID(self.referenceToRas.GetID()) is None):
-      self.referenceToRas = slicer.util.getNode('ReferenceToRas')
+      self.referenceToRas = slicer.mrmlScene.GetFirstNodeByName('ReferenceToRas')
       if self.referenceToRas is None:
         self.referenceToRas = slicer.vtkMRMLLinearTransformNode()
         self.referenceToRas.SetName("ReferenceToRas")
@@ -144,7 +144,7 @@ class UltraSound(object):
 
     # live ultrasound
     liveUltrasoundNodeName = self.guideletParent.parameterNode.GetParameter('LiveUltrasoundNodeName')
-    self.liveUltrasoundNode_Reference = slicer.util.getNode(liveUltrasoundNodeName)
+    self.liveUltrasoundNode_Reference = slicer.mrmlScene.GetFirstNodeByName(liveUltrasoundNodeName)
     if not self.liveUltrasoundNode_Reference:
       imageSpacing=[0.2, 0.2, 0.2]
       # Create an empty image volume
@@ -164,7 +164,7 @@ class UltraSound(object):
       slicer.mrmlScene.AddNode(self.liveUltrasoundNode_Reference)
       displayNode=slicer.vtkMRMLScalarVolumeDisplayNode()
       slicer.mrmlScene.AddNode(displayNode)
-      colorNode = slicer.util.getNode('Grey')
+      colorNode = slicer.mrmlScene.GetFirstNodeByName('Grey')
       displayNode.SetAndObserveColorNodeID(colorNode.GetID())
       self.liveUltrasoundNode_Reference.SetAndObserveDisplayNodeID(displayNode.GetID())
 
@@ -179,7 +179,7 @@ class UltraSound(object):
     # Set up volume reslice driver.
     resliceLogic = slicer.modules.volumereslicedriver.logic()
     if resliceLogic:
-      redNode = slicer.util.getNode('vtkMRMLSliceNodeRed')
+      redNode = slicer.mrmlScene.GetNodeByID('vtkMRMLSliceNodeRed')
       # Typically the image is zoomed in, therefore it is faster if the original resolution is used
       # on the 3D slice (and also we can show the full image and not the shape and size of the 2D view)
       redNode.SetSliceResolutionMode(slicer.vtkMRMLSliceNode.SliceResolutionMatchVolumes)
@@ -209,7 +209,7 @@ class UltraSound(object):
     self.brigthnessContrastButtonBrighter.disconnect('clicked()', self.onBrightnessContrastBrighterClicked)
 
   def createPlusConnector(self):
-    connectorNode = slicer.util.getNode('PlusConnector')
+    connectorNode = slicer.mrmlScene.GetFirstNodeByName('PlusConnector')
     if not connectorNode:
       connectorNode = slicer.vtkMRMLIGTLConnectorNode()
       connectorNode.SetLogErrorIfServerConnectionFailed(False)

--- a/Guidelet/GuideletLoadable.py
+++ b/Guidelet/GuideletLoadable.py
@@ -73,7 +73,7 @@ class GuideletWidget(ScriptedLoadableModuleWidget):
     hbox.addWidget(self.plusServerHostNamePortLineEdit)
     self.launcherFormLayout.addRow(hbox)
 
-    lnNode = slicer.util.getNode(self.moduleName)
+    lnNode = slicer.mrmlScene.GetFirstNodeByName(self.moduleName)
     if lnNode is not None and lnNode.GetParameter('PlusServerHostNamePort'):
         #logging.debug("There is already a connector PlusServerHostNamePort parameter " + lnNode.GetParameter('PlusServerHostNamePort'))
         self.plusServerHostNamePortLineEdit.setDisabled(True)


### PR DESCRIPTION
Replaced usages of slicer.util.getNode with slicer.mrmlScene.GetNode functions because slicer.util.getNode behavior was modified in Slicer 4.9. This change is also backwards compatible with Slicer 4.8.