### PR TITLE
Added HasBorderInFullScreen Setting

### DIFF
--- a/Guidelet/GuideletLoadable.py
+++ b/Guidelet/GuideletLoadable.py
@@ -131,6 +131,11 @@ class GuideletWidget(ScriptedLoadableModuleWidget):
 
     if not self.guideletInstance:
       self.guideletInstance = self.createGuideletInstance()
+
+    settings = slicer.app.userSettings()
+    hasBorder = settings.value(self.moduleName + '/Configurations/' + self.selectedConfigurationName + '/HasBorderInFullScreen') == 'True'
+    slicer.app.setHasBorderInFullScreen(hasBorder)
+
     self.guideletInstance.setupScene()
     self.guideletInstance.onSceneLoaded()
     self.guideletInstance.showFullScreen()
@@ -193,6 +198,7 @@ class GuideletLogic(ScriptedLoadableModuleLogic):
                    'UltrasoundBrightnessControl' : 'Buttons',
                    'RecordingEnabledWhenConnectorNodeDisconnected' : 'False',
                    'PLUSCaptureDeviceName' : 'CaptureDevice', # If '', no PLUS recordings are saved.
+                   'HasBorderInFullScreen' : 'False', # If True, allows certain Qt widgets to appear properly with Qt versions >= 5.
                    }
     self.updateSettings(settingList, 'Default')
 


### PR DESCRIPTION
On Windows with Qt 5, turning on OpenGL and using Slicer's full screen mode (mainWindow=slicer.util.mainWindow().showFullScreen()),
menus and tooltips (among others) are no longer visible.

By enabling setHasBorderInFullScreen in your guidelet through the 'HasBorderInFullScreen' setting, a one pixel border is added around the window, which fixes the problem.

See http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows for more details on the issue.