### PR TITLE
Adding 100ms to invalid test

### DIFF
--- a/ToolWatchdog/Testing/Python/WatchdogSelfTest.py
+++ b/ToolWatchdog/Testing/Python/WatchdogSelfTest.py
@@ -168,7 +168,7 @@ class WatchdogSelfTestTest(ScriptedLoadableModuleTest):
       watchdogNode.GetWatchedNode(watchedNodeIndex).Modified()
       self.delayDisplay("Wait for the transform name to update",200.0)
       self.assertEqual(statusCheckBox.toolTip, "<p>valid</p>")
-    self.delayDisplay("Wait for the node to become outdated",1000.0)
+    self.delayDisplay("Wait for the node to become outdated",1100.0)
     self.assertEqual(statusCheckBox.toolTip, "<p>invalid</p>")
 
     #remove module node


### PR DESCRIPTION
Test delay was 1.0s, timeout time is 1.0s, test completion is dependent on machine timing, load, etc... adding a small offset should test correctly