### PR TITLE
ENH: Add node references in the registration modules

### DIFF
--- a/FiducialRegistrationWizard/Logic/vtkSlicerFiducialRegistrationWizardLogic.cxx
+++ b/FiducialRegistrationWizard/Logic/vtkSlicerFiducialRegistrationWizardLogic.cxx
@@ -459,6 +459,8 @@ bool vtkSlicerFiducialRegistrationWizardLogic::UpdateCalibration(vtkMRMLNode* no
   completeMessage << "Registration Complete. RMS Error: " << rmsError;
   fiducialRegistrationWizardNode->AddToCalibrationStatusMessage(completeMessage.str());
   fiducialRegistrationWizardNode->SetCalibrationError( rmsError );
+  outputTransformNode->AddNodeReferenceID(vtkMRMLTransformNode::GetMovingNodeReferenceRole(), fromMarkupsFiducialNode->GetID());
+  outputTransformNode->AddNodeReferenceID(vtkMRMLTransformNode::GetFixedNodeReferenceRole(), toMarkupsFiducialNode->GetID());
   return true;
 }
 

--- a/FiducialsToModelRegistration/FiducialsToModelRegistration.py
+++ b/FiducialsToModelRegistration/FiducialsToModelRegistration.py
@@ -218,6 +218,8 @@ class FiducialsToModelRegistrationLogic(ScriptedLoadableModuleLogic):
     icpTransform.Update()
 
     outputTransform.SetMatrixTransformToParent( icpTransform.GetMatrix() )
+    outputTransform.AddNodeReferenceID(slicer.vtkMRMLTransformNode.GetMovingNodeReferenceRole(), inputFiducials.GetID())
+    outputTransform.AddNodeReferenceID(slicer.vtkMRMLTransformNode.GetFixedNodeReferenceRole(), inputModel.GetID())
 
     return True
 
@@ -241,7 +243,7 @@ class FiducialsToModelRegistrationLogic(ScriptedLoadableModuleLogic):
       transformedPoint = [0, 0, 0, 1]
       #transform.GetTransformToParent().TransformVector( originalPoint, transformedPoint )
       originalPoint.append(1)
-      transform.GetTransformToParent().MultiplyPoint( originalPoint, transformedPoint )      
+      transform.GetTransformToParent().MultiplyPoint( originalPoint, transformedPoint )
       #transformedPoints.InsertNextPoint( transformedPoint )
       surfacePoint = [0, 0, 0]
       transformedPoint.pop()

--- a/ModelRegistration/ModelRegistration.py
+++ b/ModelRegistration/ModelRegistration.py
@@ -196,6 +196,8 @@ class ModelRegistrationLogic(ScriptedLoadableModuleLogic):
     icpTransform.Update()
 
     outputSourceToTargetTransform.SetMatrixTransformToParent( icpTransform.GetMatrix() )
+    outputSourceToTargetTransform.AddNodeReferenceID(slicer.vtkMRMLTransformNode.GetMovingNodeReferenceRole(), inputSourceModel.GetID())
+    outputSourceToTargetTransform.AddNodeReferenceID(slicer.vtkMRMLTransformNode.GetFixedNodeReferenceRole(), inputTargetModel.GetID())
 
     return True
 
@@ -211,7 +213,7 @@ class ModelRegistrationLogic(ScriptedLoadableModuleLogic):
     locator.SetDataSet( targetPolyData )
     locator.SetNumberOfCellsPerBucket( 1 )
     locator.BuildLocator()
-    
+
     totalDistance = 0.0
 
     sourcePoints = sourcePolyData.GetPoints()
@@ -223,7 +225,7 @@ class ModelRegistrationLogic(ScriptedLoadableModuleLogic):
       transformedSourcePointPos = [0, 0, 0, 1]
       #transform.GetTransformToParent().TransformVector( sourcePointPos, transformedSourcePointPos )
       sourcePointPos.append(1)
-      transform.GetTransformToParent().MultiplyPoint( sourcePointPos, transformedSourcePointPos )      
+      transform.GetTransformToParent().MultiplyPoint( sourcePointPos, transformedSourcePointPos )
       #transformedPoints.InsertNextPoint( transformedSourcePointPos )
       surfacePoint = [0, 0, 0]
       transformedSourcePointPos.pop()


### PR DESCRIPTION
This is related to the recent changes in Slicer, SlicerExecutionModel, and BRAINSTools, the goal of which is to update registration modules to have the output transforms reference the inputs (images/fiducial lists/models, fixed and moving separately).