### PR TITLE
Fixed Python 3 absolute imports and unicode function. 

### DIFF
--- a/Guidelet/GuideletLib/Guidelet.py
+++ b/Guidelet/GuideletLib/Guidelet.py
@@ -41,17 +41,17 @@ class Guidelet(object):
     else:
       logging.debug("Timeout. Command Id: {0}".format(commandId))
 
-    # Guidelet layout name definitions
-    VIEW_ULTRASOUND = unicode("Ultrasound")
-    VIEW_ULTRASOUND_3D = unicode("Ultrasound + 3D")
-    VIEW_3D_ULTRASOUND = unicode("3D + Ultrasound")
-    VIEW_ULTRASOUND_CAM_3D = unicode("Ultrasound + Webcam + 3D")
-    VIEW_ULTRASOUND_DUAL_3D = unicode("Ultrasound + Dual 3D")
-    VIEW_3D = unicode("3D")
-    VIEW_DUAL_3D = unicode("Dual 3D")
-    VIEW_TRIPLE_3D = unicode("Triple 3D")
-    VIEW_TRIPLE_3D_PARALLEL = unicode("Triple 3D Parallel")
-    VIEW_QUAD_3D = unicode("Quad 3D")
+  # Guidelet layout name definitions
+  VIEW_ULTRASOUND = unicode("Ultrasound")
+  VIEW_ULTRASOUND_3D = unicode("Ultrasound + 3D")
+  VIEW_3D_ULTRASOUND = unicode("3D + Ultrasound")
+  VIEW_ULTRASOUND_CAM_3D = unicode("Ultrasound + Webcam + 3D")
+  VIEW_ULTRASOUND_DUAL_3D = unicode("Ultrasound + Dual 3D")
+  VIEW_3D = unicode("3D")
+  VIEW_DUAL_3D = unicode("Dual 3D")
+  VIEW_TRIPLE_3D = unicode("Triple 3D")
+  VIEW_TRIPLE_3D_PARALLEL = unicode("Triple 3D Parallel")
+  VIEW_QUAD_3D = unicode("Quad 3D")
 
   def __init__(self, parent, logic, configurationName='Default', sliceletDockWidgetPosition = qt.Qt.LeftDockWidgetArea):
     logging.debug('Guidelet.__init__')

--- a/Guidelet/GuideletLib/Guidelet.py
+++ b/Guidelet/GuideletLib/Guidelet.py
@@ -225,7 +225,7 @@ class Guidelet(object):
     pass
 
   def registerLayout(self, layoutName, layoutId, layoutXmlDescription, layoutSelectCallback=None):
-    if (type(layoutName) != str and type(layoutName)!= unicode) or len(layoutName) < 1:
+    if (type(layoutName) != str and type(layoutName) != unicode) or len(layoutName) < 1:
       logging.error('Failed to register layout, because layout name must be a non-empty string. Got ' + repr(layoutName))
       return False
     if not isinstance(layoutId, int):

--- a/Guidelet/GuideletLib/Guidelet.py
+++ b/Guidelet/GuideletLib/Guidelet.py
@@ -3,6 +3,10 @@ from __main__ import vtk, qt, ctk, slicer
 import logging
 import time
 
+# fix unicode error by aliasing str as unicode in Python 3
+if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion >= 4 and slicer.app.minorVersion >= 11):
+  unicode = str
+
 from .UltraSound import UltraSound
 
 class Guidelet(object):
@@ -37,17 +41,17 @@ class Guidelet(object):
     else:
       logging.debug("Timeout. Command Id: {0}".format(commandId))
 
-  # Guidelet layout name definitions
-  VIEW_ULTRASOUND = ("Ultrasound").encode
-  VIEW_ULTRASOUND_3D = ("Ultrasound + 3D").encode
-  VIEW_3D_ULTRASOUND = ("3D + Ultrasound").encode
-  VIEW_ULTRASOUND_CAM_3D = ("Ultrasound + Webcam + 3D").encode
-  VIEW_ULTRASOUND_DUAL_3D = ("Ultrasound + Dual 3D").encode
-  VIEW_3D = ("3D").encode
-  VIEW_DUAL_3D = ("Dual 3D").encode
-  VIEW_TRIPLE_3D = ("Triple 3D").encode
-  VIEW_TRIPLE_3D_PARALLEL = ("Triple 3D Parallel").encode
-  VIEW_QUAD_3D = ("Quad 3D").encode
+    # Guidelet layout name definitions
+    VIEW_ULTRASOUND = unicode("Ultrasound")
+    VIEW_ULTRASOUND_3D = unicode("Ultrasound + 3D")
+    VIEW_3D_ULTRASOUND = unicode("3D + Ultrasound")
+    VIEW_ULTRASOUND_CAM_3D = unicode("Ultrasound + Webcam + 3D")
+    VIEW_ULTRASOUND_DUAL_3D = unicode("Ultrasound + Dual 3D")
+    VIEW_3D = unicode("3D")
+    VIEW_DUAL_3D = unicode("Dual 3D")
+    VIEW_TRIPLE_3D = unicode("Triple 3D")
+    VIEW_TRIPLE_3D_PARALLEL = unicode("Triple 3D Parallel")
+    VIEW_QUAD_3D = unicode("Quad 3D")
 
   def __init__(self, parent, logic, configurationName='Default', sliceletDockWidgetPosition = qt.Qt.LeftDockWidgetArea):
     logging.debug('Guidelet.__init__')
@@ -221,7 +225,7 @@ class Guidelet(object):
     pass
 
   def registerLayout(self, layoutName, layoutId, layoutXmlDescription, layoutSelectCallback=None):
-    if (type(layoutName) != str) or len(layoutName) < 1:
+    if (type(layoutName) != str and type(layoutName)!= unicode) or len(layoutName) < 1:
       logging.error('Failed to register layout, because layout name must be a non-empty string. Got ' + repr(layoutName))
       return False
     if not isinstance(layoutId, int):

--- a/Guidelet/GuideletLib/Guidelet.py
+++ b/Guidelet/GuideletLib/Guidelet.py
@@ -3,7 +3,7 @@ from __main__ import vtk, qt, ctk, slicer
 import logging
 import time
 
-from UltraSound import UltraSound
+from .UltraSound import UltraSound
 
 class Guidelet(object):
   @staticmethod
@@ -38,16 +38,16 @@ class Guidelet(object):
       logging.debug("Timeout. Command Id: {0}".format(commandId))
 
   # Guidelet layout name definitions
-  VIEW_ULTRASOUND = unicode("Ultrasound")
-  VIEW_ULTRASOUND_3D = unicode("Ultrasound + 3D")
-  VIEW_3D_ULTRASOUND = unicode("3D + Ultrasound")
-  VIEW_ULTRASOUND_CAM_3D = unicode("Ultrasound + Webcam + 3D")
-  VIEW_ULTRASOUND_DUAL_3D = unicode("Ultrasound + Dual 3D")
-  VIEW_3D = unicode("3D")
-  VIEW_DUAL_3D = unicode("Dual 3D")
-  VIEW_TRIPLE_3D = unicode("Triple 3D")
-  VIEW_TRIPLE_3D_PARALLEL = unicode("Triple 3D Parallel")
-  VIEW_QUAD_3D = unicode("Quad 3D")
+  VIEW_ULTRASOUND = ("Ultrasound").encode
+  VIEW_ULTRASOUND_3D = ("Ultrasound + 3D").encode
+  VIEW_3D_ULTRASOUND = ("3D + Ultrasound").encode
+  VIEW_ULTRASOUND_CAM_3D = ("Ultrasound + Webcam + 3D").encode
+  VIEW_ULTRASOUND_DUAL_3D = ("Ultrasound + Dual 3D").encode
+  VIEW_3D = ("3D").encode
+  VIEW_DUAL_3D = ("Dual 3D").encode
+  VIEW_TRIPLE_3D = ("Triple 3D").encode
+  VIEW_TRIPLE_3D_PARALLEL = ("Triple 3D Parallel").encode
+  VIEW_QUAD_3D = ("Quad 3D").encode
 
   def __init__(self, parent, logic, configurationName='Default', sliceletDockWidgetPosition = qt.Qt.LeftDockWidgetArea):
     logging.debug('Guidelet.__init__')
@@ -221,7 +221,7 @@ class Guidelet(object):
     pass
 
   def registerLayout(self, layoutName, layoutId, layoutXmlDescription, layoutSelectCallback=None):
-    if (type(layoutName) != str and type(layoutName) != unicode) or len(layoutName) < 1:
+    if (type(layoutName) != str) or len(layoutName) < 1:
       logging.error('Failed to register layout, because layout name must be a non-empty string. Got ' + repr(layoutName))
       return False
     if not isinstance(layoutId, int):

--- a/Guidelet/GuideletLib/__init__.py
+++ b/Guidelet/GuideletLib/__init__.py
@@ -1,2 +1,2 @@
-from UltraSound import UltraSound
-from Guidelet import Guidelet
+from .UltraSound import UltraSound
+from .Guidelet import Guidelet

--- a/Guidelet/__init__.py
+++ b/Guidelet/__init__.py
@@ -1,2 +1,2 @@
-from GuideletLoadable import GuideletLoadable, GuideletLogic, GuideletTest, GuideletWidget
-from GuideletLib import Guidelet
+from .GuideletLoadable import GuideletLoadable, GuideletLogic, GuideletTest, GuideletWidget
+from .GuideletLib import Guidelet


### PR DESCRIPTION
I added absolute imports. I changed the unicode() function to the str.encode() string method for Python 3. I removed a condition that checked unicode() in addition to str() because they are now the same in Python 3.