### PR TITLE
Add cast to list around map for Python 3 compatibility

### DIFF
--- a/Guidelet/GuideletLoadable.py
+++ b/Guidelet/GuideletLoadable.py
@@ -237,14 +237,14 @@ class GuideletLogic(ScriptedLoadableModuleLogic):
     for r in range(4):
       for c in range(4):
         transformMatrixArray.append(transformMatrix.GetElement(r,c))
-    transformMatrixString = ' '.join(map(str, transformMatrixArray)) # string, numbers are separated by spaces
+    transformMatrixString = ' '.join(list(map(str, transformMatrixArray))) # string, numbers are separated by spaces
     settings = slicer.app.userSettings()
     settingString = self.moduleName + '/Configurations/' + configurationName + '/{0}' # Write to selected configuration
     settings.setValue(settingString.format(transformName), transformMatrixString)
 
   def createMatrixFromString(self, transformMatrixString):
     transformMatrix = vtk.vtkMatrix4x4()
-    transformMatrixArray = map(float, transformMatrixString.split(' '))
+    transformMatrixArray = list(map(float, transformMatrixString.split(' ')))
     for r in range(4):
       for c in range(4):
         transformMatrix.SetElement(r,c, transformMatrixArray[r*4+c])


### PR DESCRIPTION
Map (along with several other functions) no longer return lists in Python 3, this casts the iterable into a list to allow the rest of the function to execute as normal.