### PR TITLE
BUG: Fix error on startup in Guidelet

### DIFF
--- a/Guidelet/GuideletLib/Guidelet.py
+++ b/Guidelet/GuideletLib/Guidelet.py
@@ -82,7 +82,7 @@ class Guidelet(object):
     self.sliceletPanelLayout = qt.QVBoxLayout(self.sliceletPanel)
     self.sliceletDockWidget.setWidget(self.sliceletPanel)
 
-    self.topPanelLayout = qt.QGridLayout(self.sliceletPanel)
+    self.topPanelLayout = qt.QGridLayout()
     self.sliceletPanelLayout.addLayout(self.topPanelLayout)
     self.setupTopPanel()
 


### PR DESCRIPTION
Creating two layouts for the same frame caused the error "QLayout: Attempting to add QLayout "" to QFrame "", which already has a layout" to be thrown when starting a Guidelet. This is a problem if one tries to rely on the error icon for actual errors, and makes reading logs more difficult.