### PR TITLE
Make Fiducials-to-models registration logic available to other python modules

### DIFF
--- a/FiducialsToModelRegistration/FiducialsToModelRegistration.py
+++ b/FiducialsToModelRegistration/FiducialsToModelRegistration.py
@@ -283,31 +283,53 @@ class FiducialsToModelRegistrationLogic(ScriptedLoadableModuleLogic):
 
 
 class FiducialsToModelRegistrationTest(ScriptedLoadableModuleTest):
-  """
-  This is the test case for your scripted module.
-  """
+  """This is the test case for Fiducials-To-Model Registration Module."""
 
   def setUp(self):
-    """ Do whatever is needed to reset the state - typically a scene clear will be enough.
-    """
+    """Clear the scene."""
+    slicer.mrmlScene.Clear(0)
+
+  def tearDown(self):
+    """Clean up after the tests."""
     slicer.mrmlScene.Clear(0)
 
   def runTest(self):
-    """Run as few or as many tests as needed here.
-    """
+    """Run test scenarios."""
     self.setUp()
     self.test_FiducialsToModelRegistration1()
+    self.setUp()
 
   def test_FiducialsToModelRegistration1(self):
-    """ Ideally you should have several levels of tests.  At the lowest level
-    tests sould exercise the functionality of the logic with different inputs
-    (both valid and invalid).  At higher levels your tests should emulate the
-    way the user would interact with your code and confirm that it still works
-    the way you intended.
-    One of the most important features of the tests is that it should alert other
-    developers when their changes will have an impact on the behavior of your
-    module.  For example, if a developer removes a feature that you depend on,
-    your test should break so they know that the feature is needed.
     """
+    Test FiducialsToModelRegistrationLogic.
 
-    self.delayDisplay('Tests are not implemented for FiducialsToModelRegistration')
+    This test scenario:
+    - Creates and adds a cylinder model to the scene
+    - Creates 3 markup fiducials (points)
+    - Runs module processing logic to register points against the cylinder
+    """
+    # Create and add cylinder to the scene.
+    s = vtk.vtkCylinderSource()
+    s.SetHeight(100)
+    s.SetRadius(50)
+    s.SetResolution(50)
+    s.Update()
+    inputModel = slicer.modules.models.logic().AddModel(s.GetOutput())
+
+    # Create and add markup fiducials to the scene.
+    slicer.modules.markups.logic().AddFiducial(40, -20, 33)
+    slicer.modules.markups.logic().AddFiducial(40, -25, 37)
+    slicer.modules.markups.logic().AddFiducial(52, -28, 42)
+
+    # Create output transform node
+    transformNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
+
+    # Run module logic with default settings
+    logic = slicer.modules.fiducialstomodelregistration.widgetRepresentation().self().logic
+
+    inputFiducials = slicer.util.getNode("F")
+    success = logic.run(inputFiducials, inputModel, transformNode)
+
+    self.assertEqual(success, True)
+
+    self.delayDisplay('Test passed\n')

--- a/FiducialsToModelRegistration/FiducialsToModelRegistration.py
+++ b/FiducialsToModelRegistration/FiducialsToModelRegistration.py
@@ -169,6 +169,9 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
     # Add vertical spacer
     self.layout.addStretch(1)
 
+    # Instantiate the logic class
+    self.logic = FiducialsToModelRegistrationLogic()
+
 
   def cleanup(self):
     pass
@@ -179,15 +182,15 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
                                and self.inputFiducialSelector.currentNode()
 
   def onApplyButton(self):
-    logic = FiducialsToModelRegistrationLogic()
 
     inputFiducials = self.inputFiducialSelector.currentNode()
     inputModel = self.inputModelSelector.currentNode()
     outputTransform = self.outputSelector.currentNode()
 
-    logic.run(inputFiducials, inputModel, outputTransform, self.typeSelector.currentIndex, self.iterationSpin.value )
+    self.logic.run(inputFiducials, inputModel, outputTransform,
+                   self.typeSelector.currentIndex, self.iterationSpin.value)
 
-    self.outputLine.setText( logic.ComputeMeanDistance(inputFiducials, inputModel, outputTransform) )
+    self.outputLine.setText(self.logic.ComputeMeanDistance(inputFiducials, inputModel, outputTransform))
 
 #
 # FiducialsToModelRegistrationLogic

--- a/FiducialsToModelRegistration/FiducialsToModelRegistration.py
+++ b/FiducialsToModelRegistration/FiducialsToModelRegistration.py
@@ -11,10 +11,10 @@ from slicer.ScriptedLoadableModule import *
 class FiducialsToModelRegistration(ScriptedLoadableModule):
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
-    self.parent.title = "Fiducials-Model Registration" # TODO make this more human readable by adding spaces
+    self.parent.title = "Fiducials-Model Registration"
     self.parent.categories = ["IGT"]
     self.parent.dependencies = []
-    self.parent.contributors = ["Tamas Ungi (Queen's University"] # replace with "Firstname Lastname (Organization)"
+    self.parent.contributors = ["Tamas Ungi (Queen's University"]
     self.parent.helpText = """
 This module registers fiducial list to a model surface using iterative closest points (ICP) method.
 For help on how to use this module visit: <a href='https://www.slicerigt.org'>SlicerIGT website</a>.
@@ -22,7 +22,7 @@ For help on how to use this module visit: <a href='https://www.slicerigt.org'>Sl
     self.parent.acknowledgementText = """
 This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
 and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR013218-12S1.
-""" # replace with organization, grant and thanks.
+"""
 
 #
 # FiducialsToModelRegistrationWidget
@@ -47,42 +47,42 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
     #
     # input fiducial list selector
     #
-    fiducialWarningLabel = qt.QLabel( "Note: Parent transforms of fiducials are not used. Fiducials should be defined in the coordinate system that is being registered." )
-    fiducialWarningLabel.setWordWrap( True )
+    fiducialWarningLabel = qt.QLabel("Note: Parent transforms of fiducials are not used. Fiducials should be defined in the coordinate system that is being registered.")
+    fiducialWarningLabel.setWordWrap(True)
     parametersFormLayout.addRow(fiducialWarningLabel)
 
     self.inputFiducialSelector = slicer.qMRMLNodeComboBox()
-    self.inputFiducialSelector.nodeTypes = ( ("vtkMRMLMarkupsFiducialNode"), "" )
+    self.inputFiducialSelector.nodeTypes = (("vtkMRMLMarkupsFiducialNode"), "")
     self.inputFiducialSelector.selectNodeUponCreation = True
     self.inputFiducialSelector.addEnabled = False
     self.inputFiducialSelector.removeEnabled = False
     self.inputFiducialSelector.noneEnabled = False
     self.inputFiducialSelector.showHidden = False
     self.inputFiducialSelector.showChildNodeTypes = False
-    self.inputFiducialSelector.setMRMLScene( slicer.mrmlScene )
-    self.inputFiducialSelector.setToolTip( "Pick the input fiducial list for the algorithm." )
+    self.inputFiducialSelector.setMRMLScene(slicer.mrmlScene)
+    self.inputFiducialSelector.setToolTip("Pick the input fiducial list for the algorithm.")
     parametersFormLayout.addRow("Input fiducials: ", self.inputFiducialSelector)
 
     #
     # input model selector
     #
     self.inputModelSelector = slicer.qMRMLNodeComboBox()
-    self.inputModelSelector.nodeTypes = ( ("vtkMRMLModelNode"), "" )
+    self.inputModelSelector.nodeTypes = (("vtkMRMLModelNode"), "")
     self.inputModelSelector.selectNodeUponCreation = True
     self.inputModelSelector.addEnabled = False
     self.inputModelSelector.removeEnabled = False
     self.inputModelSelector.noneEnabled = False
     self.inputModelSelector.showHidden = False
     self.inputModelSelector.showChildNodeTypes = False
-    self.inputModelSelector.setMRMLScene( slicer.mrmlScene )
-    self.inputModelSelector.setToolTip( "Pick the input model for the algorithm." )
+    self.inputModelSelector.setMRMLScene(slicer.mrmlScene)
+    self.inputModelSelector.setToolTip("Pick the input model for the algorithm.")
     parametersFormLayout.addRow("Input model: ", self.inputModelSelector)
 
     #
     # output transform selector
     #
     self.outputSelector = slicer.qMRMLNodeComboBox()
-    self.outputSelector.nodeTypes = ( ("vtkMRMLLinearTransformNode"), "" )
+    self.outputSelector.nodeTypes = (("vtkMRMLLinearTransformNode"), "")
     self.outputSelector.selectNodeUponCreation = True
     self.outputSelector.addEnabled = True
     self.outputSelector.removeEnabled = True
@@ -90,8 +90,8 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
     self.outputSelector.showHidden = False
     self.outputSelector.showChildNodeTypes = False
     self.outputSelector.renameEnabled = True
-    self.outputSelector.setMRMLScene( slicer.mrmlScene )
-    self.outputSelector.setToolTip( "Pick the output to the algorithm." )
+    self.outputSelector.setMRMLScene(slicer.mrmlScene)
+    self.outputSelector.setToolTip("Pick the output to the algorithm.")
     parametersFormLayout.addRow("Output transform: ", self.outputSelector)
 
     #
@@ -125,12 +125,12 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
     #
     outputCollapsibleButton = ctk.ctkCollapsibleButton()
     outputCollapsibleButton.text = "Output"
-    self.layout.addWidget( outputCollapsibleButton )
-    outputFormLayout = qt.QFormLayout( outputCollapsibleButton )
+    self.layout.addWidget(outputCollapsibleButton)
+    outputFormLayout = qt.QFormLayout(outputCollapsibleButton)
 
     self.outputLine = qt.QLineEdit()
-    self.outputLine.setReadOnly( True )
-    outputFormLayout.addRow( "Mean distance after registration:", self.outputLine )
+    self.outputLine.setReadOnly(True)
+    outputFormLayout.addRow("Mean distance after registration:", self.outputLine)
 
     #
     # Advanced parameters
@@ -147,17 +147,17 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
     # Transform type selector
     #
     self.typeSelector = qt.QComboBox()
-    self.typeSelector.insertItem( 0, "Rigid" )
-    self.typeSelector.insertItem( 1, "Similarity" )
-    self.typeSelector.insertItem( 2, "Affine" )
+    self.typeSelector.insertItem(0, "Rigid")
+    self.typeSelector.insertItem(1, "Similarity")
+    self.typeSelector.insertItem(2, "Affine")
     advancedFormLayout.addRow("Transform type: ", self.typeSelector)
 
     #
     # Iteration selector
     #
     self.iterationSpin = qt.QSpinBox()
-    self.iterationSpin.setMaximum( 1000 )
-    self.iterationSpin.setValue( 100 )
+    self.iterationSpin.setMaximum(1000)
+    self.iterationSpin.setValue(100)
     advancedFormLayout.addRow("Number of iterations:", self.iterationSpin)
 
     # connections
@@ -174,7 +174,9 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
     pass
 
   def onSelect(self):
-    self.applyButton.enabled = self.inputModelSelector.currentNode() and self.outputSelector.currentNode() and self.inputFiducialSelector.currentNode()
+    self.applyButton.enabled = self.inputModelSelector.currentNode()\
+                               and self.outputSelector.currentNode()\
+                               and self.inputFiducialSelector.currentNode()
 
   def onApplyButton(self):
     logic = FiducialsToModelRegistrationLogic()
@@ -192,86 +194,89 @@ class FiducialsToModelRegistrationWidget(ScriptedLoadableModuleWidget):
 #
 
 class FiducialsToModelRegistrationLogic(ScriptedLoadableModuleLogic):
-  """This class should implement all the actual
-  computation done by your module.  The interface
-  should be such that other python code can import
-  this class and make use of the functionality without
-  requiring an instance of the Widget
+  """Automatic registration of a model (surface mesh) to markups fiducials (point list).
+
+  Uses the iterative closest points (ICP) method.
+
+  The interface enables other python code make use of
+  the functionality without requiring an instance of the Widget.
   """
 
-  def run(self, inputFiducials, inputModel, outputTransform, transformType=0, numIterations=100 ):
-
+  def run(self, inputFiducials, inputModel, outputTransform, transformType=0, numIterations=100):
+    """Run iterative closest point registration."""
     self.delayDisplay('Running iterative closest point registration')
 
     fiducialsPolyData = vtk.vtkPolyData()
     self.FiducialsToPolyData(inputFiducials, fiducialsPolyData)
 
     icpTransform = vtk.vtkIterativeClosestPointTransform()
-    icpTransform.SetSource( fiducialsPolyData )
-    icpTransform.SetTarget( inputModel.GetPolyData() )
+    icpTransform.SetSource(fiducialsPolyData)
+    icpTransform.SetTarget(inputModel.GetPolyData())
     icpTransform.GetLandmarkTransform().SetModeToRigidBody()
     if transformType == 1:
       icpTransform.GetLandmarkTransform().SetModeToSimilarity()
     if transformType == 2:
       icpTransform.GetLandmarkTransform().SetModeToAffine()
-    icpTransform.SetMaximumNumberOfIterations( numIterations )
+    icpTransform.SetMaximumNumberOfIterations(numIterations)
     icpTransform.Modified()
     icpTransform.Update()
 
-    outputTransform.SetMatrixTransformToParent( icpTransform.GetMatrix() )
+    outputTransform.SetMatrixTransformToParent(icpTransform.GetMatrix())
     if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion >= 4 and slicer.app.minorVersion >= 11):
-      outputTransform.SetNodeReferenceID(slicer.vtkMRMLTransformNode.GetMovingNodeReferenceRole(), inputFiducials.GetID())
-      outputTransform.SetNodeReferenceID(slicer.vtkMRMLTransformNode.GetFixedNodeReferenceRole(), inputModel.GetID())
+      outputTransform.SetNodeReferenceID(slicer.vtkMRMLTransformNode.GetMovingNodeReferenceRole(),
+                                         inputFiducials.GetID())
+      outputTransform.SetNodeReferenceID(slicer.vtkMRMLTransformNode.GetFixedNodeReferenceRole(),
+                                         inputModel.GetID())
 
     return True
 
 
-  def ComputeMeanDistance(self, inputFiducials, inputModel, transform ):
+  def ComputeMeanDistance(self, inputFiducials, inputModel, transform):
     surfacePoints = vtk.vtkPoints()
     cellId = vtk.mutable(0)
     subId = vtk.mutable(0)
     dist2 = vtk.mutable(0.0)
     locator = vtk.vtkCellLocator()
-    locator.SetDataSet( inputModel.GetPolyData() )
-    locator.SetNumberOfCellsPerBucket( 1 )
+    locator.SetDataSet(inputModel.GetPolyData())
+    locator.SetNumberOfCellsPerBucket(1)
     locator.BuildLocator()
     totalDistance = 0.0
 
     n = inputFiducials.GetNumberOfFiducials()
     m = vtk.vtkMath()
-    for fiducialIndex in range( 0, n ):
+    for fiducialIndex in range(0, n):
       originalPoint = [0, 0, 0]
-      inputFiducials.GetNthFiducialPosition( fiducialIndex, originalPoint )
+      inputFiducials.GetNthFiducialPosition(fiducialIndex, originalPoint)
       transformedPoint = [0, 0, 0, 1]
-      #transform.GetTransformToParent().TransformVector( originalPoint, transformedPoint )
+      #transform.GetTransformToParent().TransformVector(originalPoint, transformedPoint)
       originalPoint.append(1)
-      transform.GetTransformToParent().MultiplyPoint( originalPoint, transformedPoint )
-      #transformedPoints.InsertNextPoint( transformedPoint )
+      transform.GetTransformToParent().MultiplyPoint(originalPoint, transformedPoint)
+      #transformedPoints.InsertNextPoint(transformedPoint)
       surfacePoint = [0, 0, 0]
       transformedPoint.pop()
-      locator.FindClosestPoint( transformedPoint, surfacePoint, cellId, subId, dist2 )
+      locator.FindClosestPoint(transformedPoint, surfacePoint, cellId, subId, dist2)
       totalDistance = totalDistance + math.sqrt(dist2)
 
-    return ( totalDistance / n )
+    return (totalDistance / n)
 
 
   def FiducialsToPolyData(self, fiducials, polyData):
 
     points = vtk.vtkPoints()
     n = fiducials.GetNumberOfFiducials()
-    for fiducialIndex in range( 0, n ):
+    for fiducialIndex in range(0, n):
       p = [0, 0, 0]
-      fiducials.GetNthFiducialPosition( fiducialIndex, p )
-      points.InsertNextPoint( p )
+      fiducials.GetNthFiducialPosition(fiducialIndex, p)
+      points.InsertNextPoint(p)
 
     tempPolyData = vtk.vtkPolyData()
-    tempPolyData.SetPoints( points )
+    tempPolyData.SetPoints(points)
 
     vertex = vtk.vtkVertexGlyphFilter()
-    vertex.SetInputData( tempPolyData )
+    vertex.SetInputData(tempPolyData)
     vertex.Update()
 
-    polyData.ShallowCopy( vertex.GetOutput() )
+    polyData.ShallowCopy(vertex.GetOutput())
 
 
 class FiducialsToModelRegistrationTest(ScriptedLoadableModuleTest):


### PR DESCRIPTION
The instantiation of the module logic was added to module setup function. Such behaviour is in-line with the ScriptedLoadableModule template generated by Slicer and gives python scripts access to the module logic.

In addition a test case for this module was added resolving the [Add FiducialsToModelRegistration tests #62](https://github.com/SlicerIGT/SlicerIGT/issues/62) issue.