### PR TITLE
COMP: Mark overriding functions with override specifier

### DIFF
--- a/BreachWarning/Logic/vtkSlicerBreachWarningLogic.h
+++ b/BreachWarning/Logic/vtkSlicerBreachWarningLogic.h
@@ -58,7 +58,7 @@ class VTK_SLICER_BREACHWARNING_MODULE_LOGIC_EXPORT vtkSlicerBreachWarningLogic :
 public:
   static vtkSlicerBreachWarningLogic *New();
   vtkTypeMacro(vtkSlicerBreachWarningLogic,vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Changes the watched model node, making sure the original color of the previously selected model node is restored
   void SetWatchedModelNode( vtkMRMLModelNode* newModel, vtkMRMLBreachWarningNode* moduleNode );
@@ -80,7 +80,7 @@ public:
   double GetLineToClosestPointThickness(vtkMRMLBreachWarningNode* moduleNode);
   void SetLineToClosestPointThickness(double thickness, vtkMRMLBreachWarningNode* moduleNode);
 
-  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData );
+  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData ) override;
 
   /// Returns true if a warning sound has to be played
   vtkGetMacro(WarningSoundPlaying, bool);
@@ -90,12 +90,12 @@ protected:
   vtkSlicerBreachWarningLogic();
   virtual ~vtkSlicerBreachWarningLogic();
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
+  virtual void RegisterNodes() override;
   
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 
   void UpdateToolState( vtkMRMLBreachWarningNode* bwNode );
   void UpdateModelColor( vtkMRMLBreachWarningNode* bwNode );

--- a/BreachWarning/MRML/vtkMRMLBreachWarningNode.h
+++ b/BreachWarning/MRML/vtkMRMLBreachWarningNode.h
@@ -54,12 +54,12 @@ public:
 
   static vtkMRMLBreachWarningNode *New();
 
-  virtual vtkMRMLNode* CreateNodeInstance();
-  virtual const char* GetNodeTagName() { return "BreachWarning"; };
-  void PrintSelf( ostream& os, vtkIndent indent );
-  virtual void ReadXMLAttributes( const char** atts );
-  virtual void WriteXML( ostream& of, int indent );
-  virtual void Copy( vtkMRMLNode *node );
+  virtual vtkMRMLNode* CreateNodeInstance() override;
+  virtual const char* GetNodeTagName() override { return "BreachWarning"; };
+  void PrintSelf( ostream& os, vtkIndent indent ) override;
+  virtual void ReadXMLAttributes( const char** atts ) override;
+  virtual void WriteXML( ostream& of, int indent ) override;
+  virtual void Copy( vtkMRMLNode *node ) override;
   
 protected:
 
@@ -125,7 +125,7 @@ public:
   const char* GetLineToClosestPointNodeID();
   void SetLineToClosestPointNodeID( const char* lineToClosestPointNodeId );
   
-  void ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData );
+  void ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData ) override;
 
 private:
 

--- a/BreachWarning/qSlicerBreachWarningModule.h
+++ b/BreachWarning/qSlicerBreachWarningModule.h
@@ -50,22 +50,22 @@ public:
   qSlicerGetTitleMacro(QTMODULE_TITLE);
   
   /// Help to use the module
-  virtual QString helpText()const;
+  virtual QString helpText() const override;
 
   /// Return acknowledgements
-  virtual QString acknowledgementText()const;
+  virtual QString acknowledgementText() const override;
 
   /// Return the authors of the module
-  virtual QStringList  contributors()const;
+  virtual QStringList  contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
   /// Return the categories for the module
-  virtual QStringList categories()const;
+  virtual QStringList categories() const override;
   
   /// Return the dependencies for the module  
-  virtual QStringList dependencies() const;
+  virtual QStringList dependencies() const override;
 
   /// Set period time of the warning sound. If period is 0.5 sec then the sound will be played 2x while inside
   /// the breach region.
@@ -84,13 +84,13 @@ public slots:
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerBreachWarningModulePrivate> d_ptr;

--- a/CollectPoints/Logic/vtkSlicerCollectPointsLogic.h
+++ b/CollectPoints/Logic/vtkSlicerCollectPointsLogic.h
@@ -51,24 +51,24 @@ public:
   
   static vtkSlicerCollectPointsLogic *New();
   vtkTypeMacro(vtkSlicerCollectPointsLogic,vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   
   void AddPoint( vtkMRMLCollectPointsNode* collectPointsNode );
   void RemoveLastPoint( vtkMRMLCollectPointsNode* collectPointsNode );
   void RemoveAllPoints( vtkMRMLCollectPointsNode* collectPointsNode );
   
-  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData );
+  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData ) override;
 
 protected:
   vtkSlicerCollectPointsLogic();
   virtual ~vtkSlicerCollectPointsLogic();
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
-  virtual void UpdateFromMRMLScene();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  virtual void RegisterNodes() override;
+  virtual void UpdateFromMRMLScene() override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 private:
 
   // Computes the sampling coordinates in the anchor coordinate system

--- a/CollectPoints/MRML/vtkMRMLCollectPointsNode.h
+++ b/CollectPoints/MRML/vtkMRMLCollectPointsNode.h
@@ -58,13 +58,13 @@ public:
   // Standard MRML node methods
   static vtkMRMLCollectPointsNode *New();  
 
-  virtual vtkMRMLNode* CreateNodeInstance();
-  virtual const char* GetNodeTagName() { return "CollectPoints"; };
-  void PrintSelf( ostream& os, vtkIndent indent );
-  virtual void ReadXMLAttributes( const char** atts );
-  virtual void WriteXML( ostream& of, int indent );
-  virtual void Copy( vtkMRMLNode *node );
-  
+  virtual vtkMRMLNode* CreateNodeInstance() override;
+  virtual const char* GetNodeTagName() override { return "CollectPoints"; };
+  void PrintSelf( ostream& os, vtkIndent indent ) override;
+  virtual void ReadXMLAttributes( const char** atts ) override;
+  virtual void WriteXML( ostream& of, int indent ) override;
+  virtual void Copy( vtkMRMLNode *node ) override;
+
 protected:
 
   vtkMRMLCollectPointsNode();
@@ -100,7 +100,7 @@ public:
   vtkGetMacro( MinimumDistance, double );
   vtkSetMacro( MinimumDistance, double );
 
-  void ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData );
+  void ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData ) override;
 
   static int GetCollectModeFromString( const char* name );
   static const char* GetCollectModeAsString( int id );

--- a/CollectPoints/qSlicerCollectPointsModule.h
+++ b/CollectPoints/qSlicerCollectPointsModule.h
@@ -44,30 +44,30 @@ public:
   qSlicerGetTitleMacro(QTMODULE_TITLE);
   
   /// Help to use the module
-  virtual QString helpText()const;
+  virtual QString helpText() const override;
 
   /// Return acknowledgements
-  virtual QString acknowledgementText()const;
+  virtual QString acknowledgementText() const override;
 
   /// Return the authors of the module
-  virtual QStringList  contributors()const;
+  virtual QStringList  contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
   /// Return the categories for the module
-  virtual QStringList categories()const;
+  virtual QStringList categories() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerCollectPointsModulePrivate> d_ptr;

--- a/CreateModels/Logic/vtkSlicerCreateModelsLogic.h
+++ b/CreateModels/Logic/vtkSlicerCreateModelsLogic.h
@@ -40,7 +40,7 @@ public:
 
   static vtkSlicerCreateModelsLogic *New();
   vtkTypeMacro(vtkSlicerCreateModelsLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // If modelNodeToUpdate is specified then instead of creating a new node, the existing node will be updated
   vtkMRMLModelNode* CreateNeedle( double length, double radius, double tipRadius, bool markers, vtkMRMLModelNode* modelNodeToUpdate = NULL );

--- a/CreateModels/qSlicerCreateModelsModule.h
+++ b/CreateModels/qSlicerCreateModelsModule.h
@@ -43,26 +43,26 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText() const override;
+  virtual QString acknowledgementText() const override;
+  virtual QStringList contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories() const override;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerCreateModelsModulePrivate> d_ptr;

--- a/FiducialRegistrationWizard/Logic/vtkSlicerFiducialRegistrationWizardLogic.h
+++ b/FiducialRegistrationWizard/Logic/vtkSlicerFiducialRegistrationWizardLogic.h
@@ -58,12 +58,12 @@ public:
   
   static vtkSlicerFiducialRegistrationWizardLogic *New();
   vtkTypeMacro(vtkSlicerFiducialRegistrationWizardLogic,vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   
   void AddFiducial( vtkMRMLLinearTransformNode* probeTransformNode );
   void AddFiducial( vtkMRMLLinearTransformNode* probeTransformNode, vtkMRMLMarkupsFiducialNode* fiducialNode );
 
-  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData );
+  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData ) override;
 
   bool UpdateCalibration( vtkMRMLNode* node );
 
@@ -76,12 +76,12 @@ protected:
   vtkSlicerFiducialRegistrationWizardLogic();
   virtual ~vtkSlicerFiducialRegistrationWizardLogic();
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
-  virtual void UpdateFromMRMLScene();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  virtual void RegisterNodes() override;
+  virtual void UpdateFromMRMLScene() override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 
 private:
   vtkSlicerFiducialRegistrationWizardLogic(const vtkSlicerFiducialRegistrationWizardLogic&); // Not implemented

--- a/FiducialRegistrationWizard/MRML/vtkMRMLFiducialRegistrationWizardNode.h
+++ b/FiducialRegistrationWizard/MRML/vtkMRMLFiducialRegistrationWizardNode.h
@@ -82,12 +82,12 @@ public:
   // Standard MRML node methods
   static vtkMRMLFiducialRegistrationWizardNode *New();
 
-  virtual vtkMRMLNode* CreateNodeInstance();
-  virtual const char* GetNodeTagName() { return "FiducialRegistrationWizard"; };
-  void PrintSelf( ostream& os, vtkIndent indent );
-  virtual void ReadXMLAttributes( const char** atts );
-  virtual void WriteXML( ostream& of, int indent );
-  virtual void Copy( vtkMRMLNode *node );
+  virtual vtkMRMLNode* CreateNodeInstance() override;
+  virtual const char* GetNodeTagName() override { return "FiducialRegistrationWizard"; };
+  void PrintSelf( ostream& os, vtkIndent indent ) override;
+  virtual void ReadXMLAttributes( const char** atts ) override;
+  virtual void WriteXML( ostream& of, int indent ) override;
+  virtual void Copy( vtkMRMLNode *node ) override;
 
 protected:
 
@@ -156,7 +156,7 @@ public:
   vtkGetMacro(WarpingTransformFromParent, bool);
   vtkBooleanMacro(WarpingTransformFromParent, bool);
 
-  void ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData );
+  void ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData ) override;
 
 private:
   // Three modes:

--- a/FiducialRegistrationWizard/qSlicerFiducialRegistrationWizardModule.h
+++ b/FiducialRegistrationWizard/qSlicerFiducialRegistrationWizardModule.h
@@ -49,33 +49,33 @@ public:
   qSlicerGetTitleMacro(QTMODULE_TITLE);
   
   /// Help to use the module
-  virtual QString helpText()const;
+  virtual QString helpText( )const override;
 
   /// Return acknowledgements
-  virtual QString acknowledgementText()const;
+  virtual QString acknowledgementText() const override;
 
   /// Return the authors of the module
-  virtual QStringList  contributors()const;
+  virtual QStringList  contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
   /// Return the categories for the module
-  virtual QStringList categories()const;
+  virtual QStringList categories() const override;
   
   /// Return the dependencies for the module  
-  virtual QStringList dependencies() const;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerFiducialRegistrationWizardModulePrivate> d_ptr;

--- a/PathExplorer/Logic/vtkSlicerPathExplorerLogic.h
+++ b/PathExplorer/Logic/vtkSlicerPathExplorerLogic.h
@@ -45,7 +45,7 @@ public:
 
   static vtkSlicerPathExplorerLogic *New();
   vtkTypeMacro(vtkSlicerPathExplorerLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   void UpdateTrajectory(vtkMRMLPathPlannerTrajectoryNode* trajectoryNode);
 
@@ -55,11 +55,11 @@ protected:
   vtkSlicerPathExplorerLogic();
   virtual ~vtkSlicerPathExplorerLogic();
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  virtual void RegisterNodes() override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 private:
 
   vtkSlicerPathExplorerLogic(const vtkSlicerPathExplorerLogic&); // Not implemented

--- a/PathExplorer/MRML/vtkMRMLPathPlannerTrajectoryNode.h
+++ b/PathExplorer/MRML/vtkMRMLPathPlannerTrajectoryNode.h
@@ -55,20 +55,20 @@ public:
   // MRMLNode methods
   //--------------------------------------------------------------------------
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() override;
   // Description:
   // Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() {return "PathPlannerTrajectory";};
+  virtual const char* GetNodeTagName() override {return "PathPlannerTrajectory";};
 
   virtual const char* GetIcon() {return ":/Icons/PathPlannerTrajectory.png";};
 
   // Description:
   // Read node attributes from XML file
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) override;
   
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) override;
 
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
@@ -80,7 +80,7 @@ public:
   // alternative method to propagate events generated in Display nodes
   virtual void ProcessMRMLEvents ( vtkObject * /*caller*/, 
                                    unsigned long /*event*/, 
-                                   void * /*callData*/ );
+                                   void * /*callData*/ ) override;
 
   /// Get/Set entry points markups node
   vtkMRMLMarkupsNode* GetEntryPointsNode();

--- a/PathExplorer/qSlicerPathExplorerModule.h
+++ b/PathExplorer/qSlicerPathExplorerModule.h
@@ -44,25 +44,25 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText() const override;
+  virtual QString acknowledgementText() const override;
+  virtual QStringList contributors() const override;
 
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories() const override;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerPathExplorerModulePrivate> d_ptr;

--- a/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.h
+++ b/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.h
@@ -52,7 +52,7 @@ public:
 
   static vtkSlicerPivotCalibrationLogic *New();
   vtkTypeMacro(vtkSlicerPivotCalibrationLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Clears all previously acquired tool transforms.
   // Call this before start adding transforms.
@@ -95,7 +95,7 @@ protected:
   vtkSlicerPivotCalibrationLogic();
   virtual ~vtkSlicerPivotCalibrationLogic();
   
-  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData );
+  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData ) override;
 
   // Returns the orientation difference in degrees between two 4x4 homogeneous transformation matrix, in degrees.
   double GetOrientationDifferenceDeg(vtkMatrix4x4* aMatrix, vtkMatrix4x4* bMatrix);

--- a/PivotCalibration/qSlicerPivotCalibrationModule.h
+++ b/PivotCalibration/qSlicerPivotCalibrationModule.h
@@ -43,26 +43,26 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText() const override;
+  virtual QString acknowledgementText() const override;
+  virtual QStringList contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories() const override;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerPivotCalibrationModulePrivate> d_ptr;

--- a/TransformProcessor/Logic/vtkSlicerTransformProcessorLogic.h
+++ b/TransformProcessor/Logic/vtkSlicerTransformProcessorLogic.h
@@ -60,7 +60,7 @@ public:
   
   static vtkSlicerTransformProcessorLogic *New();
   vtkTypeMacro( vtkSlicerTransformProcessorLogic, vtkSlicerModuleLogic );
-  void PrintSelf( ostream& os, vtkIndent indent );
+  void PrintSelf( ostream& os, vtkIndent indent ) override;
   
 public:
   // Update all output transforms that are to be updated continuously.
@@ -87,11 +87,11 @@ protected:
   vtkSlicerTransformProcessorLogic();
   ~vtkSlicerTransformProcessorLogic();
 
-  virtual void RegisterNodes();
-  virtual void SetMRMLSceneInternal( vtkMRMLScene * newScene );
-  virtual void OnMRMLSceneNodeAdded( vtkMRMLNode* node );
-  virtual void OnMRMLSceneNodeRemoved( vtkMRMLNode* node );
-  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData );;
+  virtual void RegisterNodes() override;
+  virtual void SetMRMLSceneInternal( vtkMRMLScene * newScene ) override;
+  virtual void OnMRMLSceneNodeAdded( vtkMRMLNode* node ) override;
+  virtual void OnMRMLSceneNodeRemoved( vtkMRMLNode* node ) override;
+  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData ) override;
   
 private:
   vtkSlicerTransformProcessorLogic( const vtkSlicerTransformProcessorLogic& );// Not implemented

--- a/TransformProcessor/MRML/vtkMRMLTransformProcessorNode.h
+++ b/TransformProcessor/MRML/vtkMRMLTransformProcessorNode.h
@@ -91,13 +91,13 @@ public:
 
   static vtkMRMLTransformProcessorNode *New();
   vtkTypeMacro( vtkMRMLTransformProcessorNode, vtkMRMLNode );
-  void PrintSelf( ostream& os, vtkIndent indent );
+  void PrintSelf( ostream& os, vtkIndent indent ) override;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
-  virtual void ReadXMLAttributes( const char** atts );
-  virtual void WriteXML( ostream& of, int indent );
-  virtual void Copy( vtkMRMLNode *node );
-  virtual const char* GetNodeTagName() { return "TransformProcessorParameters"; };
+  virtual vtkMRMLNode* CreateNodeInstance() override;
+  virtual void ReadXMLAttributes( const char** atts ) override;
+  virtual void WriteXML( ostream& of, int indent ) override;
+  virtual void Copy( vtkMRMLNode *node ) override;
+  virtual const char* GetNodeTagName() override { return "TransformProcessorParameters"; };
 
   // begin accessors and mutators
   vtkMRMLLinearTransformNode* GetNthInputCombineTransformNode( int n );
@@ -129,7 +129,7 @@ public:
   vtkMRMLLinearTransformNode* GetOutputTransformNode();
   void SetAndObserveOutputTransformNode( vtkMRMLLinearTransformNode* node );
   
-  void ProcessMRMLEvents( vtkObject* caller, unsigned long event, void* callData );
+  void ProcessMRMLEvents( vtkObject* caller, unsigned long event, void* callData ) override;
 
   vtkGetMacro( ProcessingMode, int );
   void SetProcessingMode( int );

--- a/TransformProcessor/qSlicerTransformProcessorModule.h
+++ b/TransformProcessor/qSlicerTransformProcessorModule.h
@@ -48,19 +48,19 @@ public:
   qSlicerGetTitleMacro(QTMODULE_TITLE);
   
   /// Help to use the module
-  virtual QString helpText()const;
+  virtual QString helpText() const override;
 
   /// Return acknowledgements
-  virtual QString acknowledgementText()const;
+  virtual QString acknowledgementText() const override;
 
   /// Return the authors of the module
-  virtual QStringList  contributors()const;
+  virtual QStringList  contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
   /// Return the categories for the module
-  virtual QStringList categories()const;
+  virtual QStringList categories() const override;
 
 public slots:
   void onNodeAddedEvent(vtkObject*, vtkObject*);
@@ -70,13 +70,13 @@ public slots:
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerTransformProcessorModulePrivate> d_ptr;

--- a/UltrasoundSnapshots/Logic/vtkSlicerUltrasoundSnapshotsLogic.h
+++ b/UltrasoundSnapshots/Logic/vtkSlicerUltrasoundSnapshotsLogic.h
@@ -44,7 +44,7 @@ public:
 
   static vtkSlicerUltrasoundSnapshotsLogic *New();
   vtkTypeMacro(vtkSlicerUltrasoundSnapshotsLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   
   void SetInputVolumeNode( vtkMRMLScalarVolumeNode* InputNode );
   vtkMRMLScalarVolumeNode* GetInputVolumeNode();
@@ -58,14 +58,14 @@ protected:
   
   int snapshotCounter; // This is only used to ensure unique MRML node names.
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
-  virtual void UpdateFromMRMLScene();
-  virtual void OnMRMLSceneEndImport();
-  virtual void OnMRMLSceneStartClose();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  virtual void RegisterNodes() override;
+  virtual void UpdateFromMRMLScene() override;
+  virtual void OnMRMLSceneEndImport() override;
+  virtual void OnMRMLSceneStartClose() override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 private:
 
   vtkSlicerUltrasoundSnapshotsLogic(const vtkSlicerUltrasoundSnapshotsLogic&); // Not implemented

--- a/UltrasoundSnapshots/qSlicerUltrasoundSnapshotsModule.h
+++ b/UltrasoundSnapshots/qSlicerUltrasoundSnapshotsModule.h
@@ -43,26 +43,26 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText() const override;
+  virtual QString acknowledgementText() const override;
+  virtual QStringList contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories() const override;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerUltrasoundSnapshotsModulePrivate> d_ptr;

--- a/VolumeResliceDriver/Logic/vtkSlicerVolumeResliceDriverLogic.h
+++ b/VolumeResliceDriver/Logic/vtkSlicerVolumeResliceDriverLogic.h
@@ -41,7 +41,7 @@ public:
   
   static vtkSlicerVolumeResliceDriverLogic *New();
   vtkTypeMacro(vtkSlicerVolumeResliceDriverLogic,vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   
   enum {
     MODE_NONE,
@@ -67,15 +67,15 @@ protected:
   vtkSlicerVolumeResliceDriverLogic();
   virtual ~vtkSlicerVolumeResliceDriverLogic();
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
-  virtual void UpdateFromMRMLScene();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
-  virtual void OnMRMLNodeModified( vtkMRMLNode* node );
+  virtual void RegisterNodes() override;
+  virtual void UpdateFromMRMLScene() override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
+  virtual void OnMRMLNodeModified( vtkMRMLNode* node ) override;
   
-  virtual void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void * callData);
+  virtual void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void * callData) override;
   
   void UpdateSliceByTransformableNode( vtkMRMLTransformableNode* tnode, vtkMRMLSliceNode* sliceNode );
   void UpdateSliceByTransformNode( vtkMRMLLinearTransformNode* tnode, vtkMRMLSliceNode* sliceNode );

--- a/VolumeResliceDriver/qSlicerVolumeResliceDriverModule.h
+++ b/VolumeResliceDriver/qSlicerVolumeResliceDriverModule.h
@@ -44,30 +44,30 @@ public:
   qSlicerGetTitleMacro(QTMODULE_TITLE);
   
   /// Help to use the module
-  virtual QString helpText()const;
+  virtual QString helpText() const override;
 
   /// Return acknowledgements
-  virtual QString acknowledgementText()const;
+  virtual QString acknowledgementText() const override;
 
   /// Return the authors of the module
-  virtual QStringList  contributors()const;
+  virtual QStringList  contributors() const override;
 
   /// Return a custom icon for the module
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
   /// Return the categories for the module
-  virtual QStringList categories()const;
+  virtual QStringList categories() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerVolumeResliceDriverModulePrivate> d_ptr;

--- a/Watchdog/Logic/vtkSlicerWatchdogLogic.h
+++ b/Watchdog/Logic/vtkSlicerWatchdogLogic.h
@@ -45,7 +45,7 @@ class VTK_SLICER_WATCHDOG_MODULE_LOGIC_EXPORT vtkSlicerWatchdogLogic :
 public:
   static vtkSlicerWatchdogLogic *New();
   vtkTypeMacro(vtkSlicerWatchdogLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   ///Every time the timer is reached this method updates the tools status and the elapsed time
   void UpdateAllWatchdogNodes(bool &watchedNodeBecomeUpToDateSound, bool &watchedNodeBecomeOutdatedSound);
@@ -66,11 +66,11 @@ protected:
   virtual ~vtkSlicerWatchdogLogic();
 
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
+  virtual void RegisterNodes() override;
 
   /// Initialize listening to MRML events
-  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene);
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
 
 private:
   vtkSlicerWatchdogLogic(const vtkSlicerWatchdogLogic&); // Not implemented

--- a/Watchdog/MRML/vtkMRMLWatchdogDisplayNode.h
+++ b/Watchdog/MRML/vtkMRMLWatchdogDisplayNode.h
@@ -37,7 +37,7 @@ class VTK_SLICER_WATCHDOG_MODULE_MRML_EXPORT vtkMRMLWatchdogDisplayNode : public
  public:
   static vtkMRMLWatchdogDisplayNode *New (  );
   vtkTypeMacro ( vtkMRMLWatchdogDisplayNode,vtkMRMLDisplayNode );
-  void PrintSelf ( ostream& os, vtkIndent indent );
+  void PrintSelf ( ostream& os, vtkIndent indent ) override;
 
   enum Position
     {
@@ -52,23 +52,23 @@ class VTK_SLICER_WATCHDOG_MODULE_MRML_EXPORT vtkMRMLWatchdogDisplayNode : public
   /// MRMLNode methods
   //--------------------------------------------------------------------------
 
-  virtual vtkMRMLNode* CreateNodeInstance (  );
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   ///
   /// Read node attributes from XML (MRML) file
-  virtual void ReadXMLAttributes ( const char** atts );
+  virtual void ReadXMLAttributes ( const char** atts ) override;
 
   ///
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML ( ostream& of, int indent );
+  virtual void WriteXML ( ostream& of, int indent ) override;
 
   ///
   /// Copy the node's attributes to this object
-  virtual void Copy ( vtkMRMLNode *node );
+  virtual void Copy ( vtkMRMLNode *node ) override;
 
   ///
   /// Get node XML tag name (like Volume, UnstructuredGrid)
-  virtual const char* GetNodeTagName ( ) {return "WatchdogDisplayNode";};
+  virtual const char* GetNodeTagName() override {return "WatchdogDisplayNode";};
 
   //--------------------------------------------------------------------------
   /// Display options

--- a/Watchdog/MRML/vtkMRMLWatchdogNode.h
+++ b/Watchdog/MRML/vtkMRMLWatchdogNode.h
@@ -34,28 +34,28 @@ class VTK_SLICER_WATCHDOG_MODULE_MRML_EXPORT vtkMRMLWatchdogNode : public vtkMRM
 public:
   static vtkMRMLWatchdogNode* New();
   vtkTypeMacro(vtkMRMLWatchdogNode, vtkMRMLDisplayableNode);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   //--------------------------------------------------------------------------
   /// MRMLNode methods
   //--------------------------------------------------------------------------
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   /// Get node XML tag name
-  virtual const char* GetNodeTagName() { return "Watchdog"; };
+  virtual const char* GetNodeTagName() override { return "Watchdog"; };
 
   /// Read node attributes from XML file
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) override;
 
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) override;
 
   /// Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) override;
 
   /// Create and observe default vtkMRMLWatchdogDisplayNode display node
-  virtual void CreateDefaultDisplayNodes();
+  virtual void CreateDefaultDisplayNodes() override;
 
   //--------------------------------------------------------------------------
   /// Watchdog-specific methods
@@ -104,7 +104,7 @@ public:
   vtkMRMLNode* GetWatchedNode(int watchedNodeIndex);
 
   /// Get notification about updates of watched nodes
-  virtual void ProcessMRMLEvents ( vtkObject * caller, unsigned long event, void * callData );
+  virtual void ProcessMRMLEvents ( vtkObject * caller, unsigned long event, void * callData ) override;
 
   /// Updates the up-to-date status of all watched nodes.
   /// If any of the statuses change then a Modified event is invoked.
@@ -119,7 +119,7 @@ protected:
 
   ///
   /// Called after a node reference ID is removed (list size decreased).
-  virtual void OnNodeReferenceRemoved(vtkMRMLNodeReference *reference);
+  virtual void OnNodeReferenceRemoved(vtkMRMLNodeReference *reference) override;
 
   // Constructor/destructor methods
   vtkMRMLWatchdogNode();

--- a/Watchdog/MRMLDM/vtkMRMLWatchdogDisplayableManager.h
+++ b/Watchdog/MRMLDM/vtkMRMLWatchdogDisplayableManager.h
@@ -39,28 +39,28 @@ public:
 
   static vtkMRMLWatchdogDisplayableManager* New();
   vtkTypeMacro(vtkMRMLWatchdogDisplayableManager,vtkMRMLAbstractDisplayableManager);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
 protected:
 
   vtkMRMLWatchdogDisplayableManager();
   virtual ~vtkMRMLWatchdogDisplayableManager();
 
-  virtual void UnobserveMRMLScene();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
-  virtual void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* callData);
+  virtual void UnobserveMRMLScene() override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
+  virtual void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* callData) override;
 
   /// Update Actors based on watchdog in the scene
-  virtual void UpdateFromMRML();
+  virtual void UpdateFromMRML() override;
 
-  virtual void OnMRMLSceneStartClose();
-  virtual void OnMRMLSceneEndClose();
+  virtual void OnMRMLSceneStartClose() override;
+  virtual void OnMRMLSceneEndClose() override;
 
-  virtual void OnMRMLSceneEndBatchProcess();
+  virtual void OnMRMLSceneEndBatchProcess() override;
 
   /// Initialize the displayable manager
-  virtual void Create();
+  virtual void Create() override;
 
 private:
 

--- a/Watchdog/qSlicerWatchdogModule.h
+++ b/Watchdog/qSlicerWatchdogModule.h
@@ -47,28 +47,28 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText() const override;
+  virtual QString acknowledgementText() const override;
+  virtual QStringList contributors() const override;
 
-  virtual QIcon icon()const;
+  virtual QIcon icon() const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories() const override;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module.
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 public slots:
-  virtual void setMRMLScene(vtkMRMLScene*);
+  virtual void setMRMLScene(vtkMRMLScene*) override;
   void onNodeAddedEvent(vtkObject*, vtkObject*);
   void onNodeRemovedEvent(vtkObject*, vtkObject*);
   void updateAllWatchdogNodes();


### PR DESCRIPTION
Adding override specifiers, as these are considered good practice for modern C++ code. Without the specifiers SlicerIGT emits >800 unnecessary warnings on macOS.