### PR TITLE
ENH: Update pivot calibration algorithm to use IGSIO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,13 @@ set(EXTENSION_CONTRIBUTORS "Tamas Ungi (Queen's University), Junichi Tokuda (Bri
 set(EXTENSION_DESCRIPTION "This extension contains modules that enable rapid prototyping of applications for image-guided interventions. Intended users should have real-time imaging and/or tracking hardware (e.g. tracked ultrasound) connected to 3D Slicer through OpenIGTLink network. Specific modules allow patient registration to the navigation coordinate system in 3D Slicer, and real-time update of tracked models and images." )
 set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/2/2b/SlicerIGTLogo.png" )
 set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/7/78/SlicerIGTScreenshot.png" )
+set(EXTENSION_DEPENDS SlicerIGSIO)
 
 #-----------------------------------------------------------------------------
 # Extension dependencies
 find_package(Slicer REQUIRED)
 include(${Slicer_USE_FILE})
+find_package(SlicerIGSIO REQUIRED)
 
 #-----------------------------------------------------------------------------
 # Extension modules

--- a/PivotCalibration/Logic/CMakeLists.txt
+++ b/PivotCalibration/Logic/CMakeLists.txt
@@ -14,6 +14,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  vtkIGSIOCalibration
   )
 
 #-----------------------------------------------------------------------------

--- a/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.cxx
+++ b/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.cxx
@@ -12,8 +12,8 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-  
-==============================================================================*/  
+
+==============================================================================*/
 
 // PivotCalibration Logic includes
 #include "vtkSlicerPivotCalibrationLogic.h"
@@ -21,6 +21,10 @@
 // MRML includes
 #include <vtkMRMLLinearTransformNode.h>
 #include "vtkMRMLScene.h"
+
+// vtkIGSIOCalibration includes
+#include <vtkIGSIOPivotCalibrationAlgo.h>
+#include <vtkIGSIOSpinCalibrationAlgo.h>
 
 // VTK includes
 #include <vtkNew.h>
@@ -34,21 +38,20 @@
 #include <cassert>
 #include <cmath>
 
-// VNL includes
-#include "vnl/algo/vnl_symmetric_eigensystem.h"
-#include "vnl/vnl_vector.h"
-#include "vnl/algo/vnl_svd.h"
-#include "vnl/algo/vnl_determinant.h"
+//----------------------------------------------------------------------------
+class vtkSlicerPivotCalibrationLogic::vtkInternal
+{
+public:
+  vtkInternal(vtkSlicerPivotCalibrationLogic* external)
+  {
+    this->External = external;
+  }
+  ~vtkInternal() = default;
 
-
-static const double PARALLEL_ANGLE_THRESHOLD_DEGREES = 20.0;
-// Note: If the needle orientation protocol changes, only the definitions of shaftAxis and secondaryAxes need to be changed
-// Define the shaft axis and the secondary shaft axis
-// Current needle orientation protocol dictates: shaft axis -z, orthogonal axis +x
-// If StylusX is parallel to ShaftAxis then: shaft axis -z, orthogonal axis +y
-static const double SHAFT_AXIS[ 3 ] = { 0, 0, -1 };
-static const double ORTHOGONAL_AXIS[ 3 ] = { 1, 0, 0 };
-static const double BACKUP_AXIS[ 3 ] = { 0, 1, 0 };
+  vtkSlicerPivotCalibrationLogic* External;
+  vtkNew<vtkIGSIOPivotCalibrationAlgo> PivotCalibrationAlgo;
+  vtkNew<vtkIGSIOSpinCalibrationAlgo> SpinCalibrationAlgo;
+};
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerPivotCalibrationLogic);
@@ -56,23 +59,22 @@ vtkStandardNewMacro(vtkSlicerPivotCalibrationLogic);
 //----------------------------------------------------------------------------
 vtkSlicerPivotCalibrationLogic::vtkSlicerPivotCalibrationLogic()
 {
+  this->Internal = new vtkInternal(this);
   this->ToolTipToToolMatrix = vtkMatrix4x4::New();
-  this->ObservedTransformNode = NULL;
-  this->MinimumOrientationDifferenceDeg = 15.0;
 }
 
 //----------------------------------------------------------------------------
 vtkSlicerPivotCalibrationLogic::~vtkSlicerPivotCalibrationLogic()
 {
-  this->ClearToolToReferenceMatrices();
+  delete this->Internal;
   this->ToolTipToToolMatrix->Delete();
-  this->SetAndObserveTransformNode( NULL ); // Remove the observer
+  this->SetAndObserveTransformNode(NULL); // Remove the observer
 }
 
 //----------------------------------------------------------------------------
 void vtkSlicerPivotCalibrationLogic::PrintSelf(ostream& os, vtkIndent indent)
 {
-  this->Superclass::PrintSelf( os, indent );
+  this->Superclass::PrintSelf(os, indent);
 }
 
 //---------------------------------------------------------------------------
@@ -81,21 +83,21 @@ void vtkSlicerPivotCalibrationLogic::ProcessMRMLNodesEvents(vtkObject* caller, u
   if (caller != NULL)
   {
     vtkMRMLLinearTransformNode* transformNode = vtkMRMLLinearTransformNode::SafeDownCast(caller);
-    if ( event == vtkMRMLLinearTransformNode::TransformModifiedEvent && this->RecordingState == true && strcmp( transformNode->GetID(), this->ObservedTransformNode->GetID() ) == 0 )
+    if (event == vtkMRMLLinearTransformNode::TransformModifiedEvent && this->RecordingState == true && strcmp(transformNode->GetID(), this->ObservedTransformNode->GetID()) == 0)
     {
-      vtkMatrix4x4* matrixCopy = vtkMatrix4x4::New();
-      transformNode->GetMatrixTransformToParent(matrixCopy);      
-      this->AddToolToReferenceMatrix(matrixCopy);
+      vtkNew<vtkMatrix4x4> toolToReferenceMatrix;
+      transformNode->GetMatrixTransformToParent(toolToReferenceMatrix);
+      this->AddToolToReferenceMatrix(toolToReferenceMatrix);
     }
   }
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerPivotCalibrationLogic::SetAndObserveTransformNode( vtkMRMLLinearTransformNode* transformNode )
+void vtkSlicerPivotCalibrationLogic::SetAndObserveTransformNode(vtkMRMLLinearTransformNode* transformNode)
 {
   vtkNew<vtkIntArray> events;
-  events->InsertNextValue( vtkMRMLLinearTransformNode::TransformModifiedEvent );
-  vtkSetAndObserveMRMLNodeEventsMacro( this->ObservedTransformNode, transformNode, events.GetPointer() );
+  events->InsertNextValue(vtkMRMLLinearTransformNode::TransformModifiedEvent);
+  vtkSetAndObserveMRMLNodeEventsMacro(this->ObservedTransformNode, transformNode, events.GetPointer());
 }
 
 //---------------------------------------------------------------------------
@@ -106,392 +108,343 @@ void vtkSlicerPivotCalibrationLogic::AddToolToReferenceMatrix(vtkMatrix4x4* tran
     vtkErrorMacro("vtkSlicerPivotCalibrationLogic::AddToolToReferenceMatrix failed: invalid transformMatrix");
     return;
   }
-  this->ToolToReferenceMatrices.push_back(transformMatrix);
+
+  this->Internal->PivotCalibrationAlgo->InsertNextCalibrationPoint(transformMatrix);
+  this->InvokeEvent(PivotInputTransformAdded);
+  if (this->PivotAutoCalibrationEnabled && this->GetPivotNumberOfPoses() >= this->PivotAutoCalibrationTargetNumberOfPoints)
+  {
+    if (this->ComputePivotCalibration() && this->PivotRMSE <= this->PivotAutoCalibrationTargetError)
+    {
+      this->InvokeEvent(vtkSlicerPivotCalibrationLogic::PivotCalibrationCompleteEvent);
+      if (this->PivotAutoCalibrationStopWhenComplete)
+      {
+        this->SetPivotAutoCalibrationEnabled(false);
+      }
+    }
+  }
+
+  this->Internal->SpinCalibrationAlgo->InsertNextCalibrationPoint(transformMatrix);
+  this->InvokeEvent(SpinInputTransformAdded);
+  if (this->SpinAutoCalibrationEnabled && this->GetSpinNumberOfPoses() >= this->SpinAutoCalibrationTargetNumberOfPoints)
+  {
+    if (this->ComputeSpinCalibration() && this->SpinRMSE <= this->SpinAutoCalibrationTargetError)
+    {
+      this->InvokeEvent(vtkSlicerPivotCalibrationLogic::SpinCalibrationCompleteEvent);
+    }
+    if (this->SpinAutoCalibrationStopWhenComplete)
+    {
+      this->SetSpinAutoCalibrationEnabled(false);
+    }
+  }
+
+  this->InvokeEvent(InputTransformAdded);
 }
 
 //---------------------------------------------------------------------------
 void vtkSlicerPivotCalibrationLogic::ClearToolToReferenceMatrices()
 {
-  std::vector<vtkMatrix4x4*>::const_iterator it;
-  std::vector<vtkMatrix4x4*>::const_iterator matricesEnd = this->ToolToReferenceMatrices.end();
-  for(it = this->ToolToReferenceMatrices.begin(); it != matricesEnd; it++)
-  {
-    (*it)->Delete();
-  }
-  this->ToolToReferenceMatrices.clear();
-}
-
-//----------------------------------------------------------------------------
-double vtkSlicerPivotCalibrationLogic::GetOrientationDifferenceDeg(vtkMatrix4x4* aMatrix, vtkMatrix4x4* bMatrix)
-{
-  vtkSmartPointer<vtkMatrix4x4> diffMatrix = vtkSmartPointer<vtkMatrix4x4>::New(); 
-  vtkSmartPointer<vtkMatrix4x4> invBmatrix = vtkSmartPointer<vtkMatrix4x4>::New(); 
-
-  vtkMatrix4x4::Invert(bMatrix, invBmatrix);  
-
-  vtkMatrix4x4::Multiply4x4(aMatrix, invBmatrix, diffMatrix); 
-
-  vtkSmartPointer<vtkTransform> diffTransform = vtkSmartPointer<vtkTransform>::New(); 
-  diffTransform->SetMatrix(diffMatrix); 
-
-  double angleDiff_rad= vtkMath::RadiansFromDegrees(diffTransform->GetOrientationWXYZ()[0]);
-
-  double normalizedAngleDiff_rad = atan2( sin(angleDiff_rad), cos(angleDiff_rad) ); // normalize angle to domain -pi, pi 
-
-  return vtkMath::DegreesFromRadians(normalizedAngleDiff_rad);
+  this->Internal->PivotCalibrationAlgo->RemoveAllCalibrationPoints();
+  this->Internal->SpinCalibrationAlgo->RemoveAllCalibrationPoints();
 }
 
 //---------------------------------------------------------------------------
-double vtkSlicerPivotCalibrationLogic::GetMaximumToolOrientationDifferenceDeg()
+void vtkSlicerPivotCalibrationLogic::ClearPivotToolToReferenceMatrices()
 {
-  // this will store the maximum difference in orientation between the first transform and all the other transforms
-  double maximumOrientationDifferenceDeg = 0;
-  
-    std::vector<vtkMatrix4x4*>::const_iterator it;
-  std::vector<vtkMatrix4x4*>::const_iterator matricesEnd = this->ToolToReferenceMatrices.end();
-  unsigned int currentRow;
-  vtkMatrix4x4* referenceOrientationMatrix = this->ToolToReferenceMatrices.front();
-  for(currentRow = 0, it = this->ToolToReferenceMatrices.begin(); it != matricesEnd; it++, currentRow += 3)
-  {
-    double orientationDifferenceDeg = GetOrientationDifferenceDeg(referenceOrientationMatrix, (*it));
-    if (maximumOrientationDifferenceDeg < orientationDifferenceDeg)
-    {
-      maximumOrientationDifferenceDeg = orientationDifferenceDeg;    
-    }
-  }
-
-  return maximumOrientationDifferenceDeg;
+  this->Internal->PivotCalibrationAlgo->RemoveAllCalibrationPoints();
 }
 
 //---------------------------------------------------------------------------
-bool vtkSlicerPivotCalibrationLogic::ComputePivotCalibration( bool autoOrient /*=true*/)
+void vtkSlicerPivotCalibrationLogic::ClearSpinToolToReferenceMatrices()
 {
-  if (this->ToolToReferenceMatrices.size() < 10)
+  this->Internal->SpinCalibrationAlgo->RemoveAllCalibrationPoints();
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetPivotErrorCode()
+{
+  return this->Internal->PivotCalibrationAlgo->GetErrorCode();
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetSpinErrorCode()
+{
+  return this->Internal->SpinCalibrationAlgo->GetErrorCode();
+}
+
+//---------------------------------------------------------------------------
+std::string vtkSlicerPivotCalibrationLogic::GetErrorCodeAsString(int errorCode)
+{
+  std::string errorText;
+  switch (errorCode)
   {
-    this->ErrorText = "Not enough input transforms are available";
+  case vtkIGSIOAbstractStylusCalibrationAlgo::CALIBRATION_NO_ERROR:
+  case vtkIGSIOAbstractStylusCalibrationAlgo::CALIBRATION_NOT_STARTED:
+    break;
+  case vtkIGSIOAbstractStylusCalibrationAlgo::CALIBRATION_NOT_ENOUGH_VARIATION:
+    errorText = "Couldn't perform calibration; not enough variation";
+    break;
+  case vtkIGSIOAbstractStylusCalibrationAlgo::CALIBRATION_NOT_ENOUGH_POINTS:
+    errorText = "Couldn't perform calibration; not enough points";
+    break;
+  case vtkIGSIOAbstractStylusCalibrationAlgo::CALIBRATION_HIGH_ERROR:
+    errorText = "Couldn't perform calibration; error is too high";
+    break;
+  default:
+  case vtkIGSIOAbstractStylusCalibrationAlgo::CALIBRATION_FAIL:
+    errorText = "Couldn't perform calibration";
+    break;
+  }
+  return errorText;
+}
+
+//---------------------------------------------------------------------------
+bool vtkSlicerPivotCalibrationLogic::ComputePivotCalibration(bool autoOrient /*=true*/)
+{
+  vtkNew<vtkMatrix4x4> toolTipToToolMatrix;
+  toolTipToToolMatrix->DeepCopy(this->ToolTipToToolMatrix);
+  this->Internal->PivotCalibrationAlgo->SetPivotPointToMarkerTransformMatrix(toolTipToToolMatrix);
+
+  bool success = this->Internal->PivotCalibrationAlgo->DoPivotCalibration(nullptr, autoOrient) == IGSIO_SUCCESS;
+  this->ErrorText = this->GetErrorCodeAsString(this->GetPivotErrorCode());
+
+  if (!success)
+  {
+    this->SetPivotRMSE(-1.0);
+    vtkErrorMacro("ComputePivotCalibration: " << this->GetErrorText());
     return false;
   }
 
-  if (this->GetMaximumToolOrientationDifferenceDeg() < this->MinimumOrientationDifferenceDeg)
-  {
-    this->ErrorText = "Not enough variation in the input transforms";
-    return false;
-  }
-  
-  unsigned int rows = 3 * this->ToolToReferenceMatrices.size();
-  unsigned int columns = 6;
-
-  vnl_matrix<double> A(rows, columns);
-
-  vnl_matrix<double> minusI(3,3,0);
-  minusI(0, 0) = -1;
-  minusI(1, 1) = -1;
-  minusI(2, 2) = -1;
-
-  vnl_matrix<double> R(3,3);
-  vnl_vector<double> b(rows);
-  vnl_vector<double> x(columns);
-  vnl_vector<double> t(3);
-
-  std::vector<vtkMatrix4x4*>::const_iterator it;
-  std::vector<vtkMatrix4x4*>::const_iterator matricesEnd = this->ToolToReferenceMatrices.end();
-  unsigned int currentRow;
-  for(currentRow = 0, it = this->ToolToReferenceMatrices.begin(); it != matricesEnd; it++, currentRow += 3)
-  {    
-    for (int i = 0; i < 3; i++)
-    {
-      t(i) = (*it)->GetElement(i, 3);
-    }
-    t *= -1;
-    b.update(t, currentRow);
-
-    for (int i = 0; i < 3; i++)
-    {
-      for (int j = 0; j < 3; j++ )
-      {
-        R(i, j) = (*it)->GetElement(i, j);
-      }
-    }
-    A.update(R, currentRow, 0);
-    A.update( minusI, currentRow, 3 );    
-  }
-    
-  vnl_svd<double> svdA(A);    
-  svdA.zero_out_absolute( 1e-1 );    
-  x = svdA.solve( b );
-    
   //set the RMSE
-  this->PivotRMSE = ( A * x - b ).rms();
+  this->SetPivotRMSE(this->Internal->PivotCalibrationAlgo->GetPivotCalibrationErrorMm());
 
   //set the transformation
-  this->ToolTipToToolMatrix->SetElement( 0, 3, x[ 0 ] );
-  this->ToolTipToToolMatrix->SetElement( 1, 3, x[ 1 ] );
-  this->ToolTipToToolMatrix->SetElement( 2, 3, x[ 2 ] );
-  if (autoOrient)
-  {
-    this->UpdateShaftDirection(); // Flip it if necessary
-  }
+  this->ToolTipToToolMatrix->DeepCopy(
+    this->Internal->PivotCalibrationAlgo->GetPivotPointToMarkerTransformMatrix());
 
-  this->ErrorText.empty();
   return true;
 }
 
 //---------------------------------------------------------------------------
-bool vtkSlicerPivotCalibrationLogic::ComputeSpinCalibration( bool snapRotation /*=false*/, bool autoOrient /*=true*/)
+bool vtkSlicerPivotCalibrationLogic::ComputeSpinCalibration(bool snapRotation /*=false*/, bool autoOrient /*=true*/)
 {
-  if ( this->ToolToReferenceMatrices.size() < 10 )
+  vtkNew<vtkMatrix4x4> toolTipToToolMatrix;
+  toolTipToToolMatrix->DeepCopy(this->ToolTipToToolMatrix);
+  this->Internal->SpinCalibrationAlgo->SetPivotPointToMarkerTransformMatrix(toolTipToToolMatrix);
+
+  bool success = this->Internal->SpinCalibrationAlgo->DoSpinCalibration(nullptr, snapRotation, autoOrient) == IGSIO_SUCCESS;
+  this->ErrorText = this->GetErrorCodeAsString(this->GetSpinErrorCode());
+
+  if (!success)
   {
-    this->ErrorText = "Not enough input transforms are available";
+    this->SetSpinRMSE(-1.0);
+    vtkErrorMacro("ComputeSpinCalibration: " << this->GetErrorText());
     return false;
-  }
-
-  if (this->GetMaximumToolOrientationDifferenceDeg() < this->MinimumOrientationDifferenceDeg)
-  {
-    this->ErrorText = "Not enough variation in the input transforms";
-    return false;
-  }
-  
-  // Setup our system to find the axis of rotation
-  unsigned int rows = 3, columns = 3;
-
-  vnl_matrix<double> A( rows, columns, 0);
-
-  vnl_matrix<double> I( 3, 3, 0 );
-  I.set_identity();
-
-  vnl_matrix<double> RI( rows, columns );
-
-  std::vector< vtkMatrix4x4* >::const_iterator previt = this->ToolToReferenceMatrices.end();
-  for(std::vector< vtkMatrix4x4* >::const_iterator it = this->ToolToReferenceMatrices.begin(); it != this->ToolToReferenceMatrices.end(); it++ )
-  {
-    if ( previt == this->ToolToReferenceMatrices.end() )
-    {
-      previt = it;
-      continue; // No comparison to make for the first matrix
-    }
-    
-    vtkSmartPointer< vtkMatrix4x4 > itinverse = vtkSmartPointer< vtkMatrix4x4 >::New();
-    vtkMatrix4x4::Invert( (*it), itinverse );
-
-    vtkSmartPointer< vtkMatrix4x4 > instRotation = vtkSmartPointer< vtkMatrix4x4 >::New();
-    vtkMatrix4x4::Multiply4x4( itinverse, (*previt), instRotation );
-
-    for (int i = 0; i < 3; i++)
-    {
-      for (int j = 0; j < 3; j++ )
-      {
-        RI(i, j) = instRotation->GetElement(i, j);
-      }
-    }
-
-    RI = RI - I;
-    A = A + RI.transpose() * RI;
-
-    previt = it;
-  }
-
-  // Setup the axes
-  vnl_vector<double> shaftAxis_Shaft( columns, columns, SHAFT_AXIS );
-  vnl_vector<double> orthogonalAxis_Shaft( columns, columns, ORTHOGONAL_AXIS );
-  vnl_vector<double> backupAxis_Shaft( columns, columns, BACKUP_AXIS );
-
-  // Find the eigenvector associated with the smallest eigenvalue
-  // This is the best axis of rotation over all instantaneous rotations
-  vnl_matrix<double> eigenvectors( columns, columns, 0 );
-  vnl_vector<double> eigenvalues( columns, 0 );
-  vnl_symmetric_eigensystem_compute( A, eigenvectors, eigenvalues );
-  // Note: eigenvectors are ordered in increasing eigenvalue ( 0 = smallest, end = biggest )
-  vnl_vector<double> shaftAxis_ToolTip( columns, 0 );
-  shaftAxis_ToolTip( 0 ) = eigenvectors( 0, 0 );
-  shaftAxis_ToolTip( 1 ) = eigenvectors( 1, 0 );
-  shaftAxis_ToolTip( 2 ) = eigenvectors( 2, 0 );
-  shaftAxis_ToolTip.normalize();
-
-  // Snap the direction vector to be exactly aligned with one of the coordinate axes
-  // This is if the sensor is known to be parallel to one of the axis, just not which one
-  if ( snapRotation )
-  {
-    int closestCoordinateAxis = element_product( shaftAxis_ToolTip, shaftAxis_ToolTip ).arg_max();
-    shaftAxis_ToolTip.fill( 0 );
-    shaftAxis_ToolTip.put( closestCoordinateAxis, 1 ); // Doesn't matter the direction, will be sorted out later
   }
 
   //set the RMSE
-  this->SpinRMSE = sqrt( eigenvalues( 0 ) / this->ToolToReferenceMatrices.size() );
-  // Note: This error is the RMS distance from the ideal axis of rotation to the axis of rotation for each instantaneous rotation
-  // This RMS distance can be computed to an angle in the following way: angle = arccos( 1 - SpinRMSE^2 / 2 )
-  // Here we elect to return the RMS distance because this is the quantity that was actually minimized in the calculation
+  this->SetSpinRMSE(this->Internal->SpinCalibrationAlgo->GetSpinCalibrationErrorMm());
 
+  //set the transformation
+  this->ToolTipToToolMatrix->DeepCopy(
+    this->Internal->SpinCalibrationAlgo->GetPivotPointToMarkerTransformMatrix());
 
-  // If the secondary axis 1 is parallel to the shaft axis in the tooltip frame, then use secondary axis 2
-  vnl_vector<double> orthogonalAxis_ToolTip = this->ComputeSecondaryAxis( shaftAxis_ToolTip );
-  // Do the registration find the appropriate rotation
-  orthogonalAxis_ToolTip = orthogonalAxis_ToolTip - dot_product( orthogonalAxis_ToolTip, shaftAxis_ToolTip ) * shaftAxis_ToolTip;
-  orthogonalAxis_ToolTip.normalize();
-
-  // Register X,Y,O points in the two coordinate frames (only spherical registration - since pure rotation)
-  vnl_matrix<double> ToolTipPoints( 3, 3, 0.0 );
-  vnl_matrix<double> ShaftPoints( 3, 3, 0.0 );
-
-  ToolTipPoints.put( 0, 0, shaftAxis_ToolTip( 0 ) );
-  ToolTipPoints.put( 0, 1, shaftAxis_ToolTip( 1 ) );
-  ToolTipPoints.put( 0, 2, shaftAxis_ToolTip( 2 ) );
-  ToolTipPoints.put( 1, 0, orthogonalAxis_ToolTip( 0 ) );
-  ToolTipPoints.put( 1, 1, orthogonalAxis_ToolTip( 1 ) );
-  ToolTipPoints.put( 1, 2, orthogonalAxis_ToolTip( 2 ) );
-  ToolTipPoints.put( 2, 0, 0 );
-  ToolTipPoints.put( 2, 1, 0 );
-  ToolTipPoints.put( 2, 2, 0 );
-
-  ShaftPoints.put( 0, 0, shaftAxis_Shaft( 0 ) );
-  ShaftPoints.put( 0, 1, shaftAxis_Shaft( 1 ) );
-  ShaftPoints.put( 0, 2, shaftAxis_Shaft( 2 ) );
-  ShaftPoints.put( 1, 0, orthogonalAxis_Shaft( 0 ) );
-  ShaftPoints.put( 1, 1, orthogonalAxis_Shaft( 1 ) );
-  ShaftPoints.put( 1, 2, orthogonalAxis_Shaft( 2 ) );
-  ShaftPoints.put( 2, 0, 0 );
-  ShaftPoints.put( 2, 1, 0 );
-  ShaftPoints.put( 2, 2, 0 );
-  
-  vnl_svd<double> ShaftToToolTipRegistrator( ShaftPoints.transpose() * ToolTipPoints );
-  vnl_matrix<double> V = ShaftToToolTipRegistrator.V();
-  vnl_matrix<double> U = ShaftToToolTipRegistrator.U();
-  vnl_matrix<double> Rotation = V * U.transpose();
-
-  // Make sure the determinant is positve (i.e. +1)
-  double determinant = vnl_determinant( Rotation );
-  if ( determinant < 0 )
-  {
-    // Switch the sign of the third column of V if the determinant is not +1
-    // This is the recommended approach from Huang et al. 1987
-    V.put( 0, 2, -V.get( 0, 2 ) );
-    V.put( 1, 2, -V.get( 1, 2 ) );
-    V.put( 2, 2, -V.get( 2, 2 ) );
-    Rotation = V * U.transpose();
-  }
-
-  // Set the elements of the output matrix
-  for (int i = 0; i < 3; i++)
-  {
-    for (int j = 0; j < 3; j++ )
-    {
-      this->ToolTipToToolMatrix->SetElement( i, j, Rotation[ i ][ j ] );
-    }
-  }
-  if (autoOrient)
-  {
-    this->UpdateShaftDirection(); // Flip it if necessary
-  }
-  
-  this->ErrorText.empty();
   return true;
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerPivotCalibrationLogic::GetToolTipToToolTranslation( vtkMatrix4x4* translationMatrix )
+void vtkSlicerPivotCalibrationLogic::GetToolTipToToolTranslation(vtkMatrix4x4* translationMatrix)
 {
   translationMatrix->Identity();
-
-  translationMatrix->SetElement( 0, 3, this->ToolTipToToolMatrix->GetElement( 0, 3 ) );
-  translationMatrix->SetElement( 1, 3, this->ToolTipToToolMatrix->GetElement( 1, 3 ) );
-  translationMatrix->SetElement( 2, 3, this->ToolTipToToolMatrix->GetElement( 2, 3 ) );
+  translationMatrix->SetElement(0, 3, this->ToolTipToToolMatrix->GetElement(0, 3));
+  translationMatrix->SetElement(1, 3, this->ToolTipToToolMatrix->GetElement(1, 3));
+  translationMatrix->SetElement(2, 3, this->ToolTipToToolMatrix->GetElement(2, 3));
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerPivotCalibrationLogic::GetToolTipToToolRotation( vtkMatrix4x4* rotationMatrix )
+void vtkSlicerPivotCalibrationLogic::GetToolTipToToolRotation(vtkMatrix4x4* rotationMatrix)
 {
   rotationMatrix->Identity();
-
-  rotationMatrix->SetElement( 0, 0, this->ToolTipToToolMatrix->GetElement( 0, 0 ) );
-  rotationMatrix->SetElement( 0, 1, this->ToolTipToToolMatrix->GetElement( 0, 1 ) );
-  rotationMatrix->SetElement( 0, 2, this->ToolTipToToolMatrix->GetElement( 0, 2 ) );
-  rotationMatrix->SetElement( 1, 0, this->ToolTipToToolMatrix->GetElement( 1, 0 ) );
-  rotationMatrix->SetElement( 1, 1, this->ToolTipToToolMatrix->GetElement( 1, 1 ) );
-  rotationMatrix->SetElement( 1, 2, this->ToolTipToToolMatrix->GetElement( 1, 2 ) );
-  rotationMatrix->SetElement( 2, 0, this->ToolTipToToolMatrix->GetElement( 2, 0 ) );
-  rotationMatrix->SetElement( 2, 1, this->ToolTipToToolMatrix->GetElement( 2, 1 ) );
-  rotationMatrix->SetElement( 2, 2, this->ToolTipToToolMatrix->GetElement( 2, 2 ) );
+  rotationMatrix->SetElement(0, 0, this->ToolTipToToolMatrix->GetElement(0, 0));
+  rotationMatrix->SetElement(0, 1, this->ToolTipToToolMatrix->GetElement(0, 1));
+  rotationMatrix->SetElement(0, 2, this->ToolTipToToolMatrix->GetElement(0, 2));
+  rotationMatrix->SetElement(1, 0, this->ToolTipToToolMatrix->GetElement(1, 0));
+  rotationMatrix->SetElement(1, 1, this->ToolTipToToolMatrix->GetElement(1, 1));
+  rotationMatrix->SetElement(1, 2, this->ToolTipToToolMatrix->GetElement(1, 2));
+  rotationMatrix->SetElement(2, 0, this->ToolTipToToolMatrix->GetElement(2, 0));
+  rotationMatrix->SetElement(2, 1, this->ToolTipToToolMatrix->GetElement(2, 1));
+  rotationMatrix->SetElement(2, 2, this->ToolTipToToolMatrix->GetElement(2, 2));
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerPivotCalibrationLogic::GetToolTipToToolMatrix( vtkMatrix4x4* matrix )
+void vtkSlicerPivotCalibrationLogic::GetToolTipToToolMatrix(vtkMatrix4x4* matrix)
 {
-  matrix->DeepCopy( this->ToolTipToToolMatrix );
+  matrix->DeepCopy(this->ToolTipToToolMatrix);
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerPivotCalibrationLogic::SetToolTipToToolMatrix( vtkMatrix4x4* matrix )
+void vtkSlicerPivotCalibrationLogic::SetToolTipToToolMatrix(vtkMatrix4x4* matrix)
 {
-  this->ToolTipToToolMatrix->DeepCopy( matrix );
-}
-
-//---------------------------------------------------------------------------
-vnl_vector< double > vtkSlicerPivotCalibrationLogic::ComputeSecondaryAxis( vnl_vector< double > shaftAxis_ToolTip )
-{
-  // If the secondary axis 1 is parallel to the shaft axis in the tooltip frame, then use secondary axis 2
-  vnl_vector< double > orthogonalAxis_Shaft( 3, 3, ORTHOGONAL_AXIS );
-  double angle = acos( dot_product( shaftAxis_ToolTip, orthogonalAxis_Shaft ) );
-  // Force angle to be between -pi/2 and +pi/2
-  if ( angle > vtkMath::Pi() / 2 )
-  {
-    angle -= vtkMath::Pi();
-  }
-  if ( angle < - vtkMath::Pi() / 2 )
-  {
-    angle += vtkMath::Pi();
-  }
-
-  if ( fabs( angle ) < vtkMath::RadiansFromDegrees( PARALLEL_ANGLE_THRESHOLD_DEGREES ) ) // If shaft axis and orthogonal axis are not parallel
-  {
-    return vnl_vector< double >( 3, 3, BACKUP_AXIS );
-  }
-  return orthogonalAxis_Shaft;
-}
-
-
-//---------------------------------------------------------------------------
-void vtkSlicerPivotCalibrationLogic::UpdateShaftDirection()
-{
-  // We need to verify that the ToolTipToTool vector in the Shaft coordinate system is in the opposite direction of the shaft
-  vtkSmartPointer< vtkMatrix4x4 > rotationMatrix = vtkSmartPointer< vtkMatrix4x4 >::New();
-  this->GetToolTipToToolRotation( rotationMatrix );
-  rotationMatrix->Invert();
-
-  double toolTipToToolTranslation_ToolTip[ 4 ] = { 0, 0, 0, 0 }; // This is a vector, not a point, so the last element is 0
-  toolTipToToolTranslation_ToolTip[ 0 ] = this->ToolTipToToolMatrix->GetElement( 0, 3 );
-  toolTipToToolTranslation_ToolTip[ 1 ] = this->ToolTipToToolMatrix->GetElement( 1, 3 );
-  toolTipToToolTranslation_ToolTip[ 2 ] = this->ToolTipToToolMatrix->GetElement( 2, 3 );
-
-  double toolTipToToolTranslation_Shaft[ 4 ] = { 0, 0, 0, 0 }; // This is a vector, not a point, so the last element is 0
-  rotationMatrix->MultiplyPoint( toolTipToToolTranslation_ToolTip, toolTipToToolTranslation_Shaft );
-  double toolTipToToolTranslation3_Shaft[ 3 ] = { toolTipToToolTranslation_Shaft[ 0 ], toolTipToToolTranslation_Shaft[ 1 ], toolTipToToolTranslation_Shaft[ 2 ] };
-  
-  // Check if it is parallel or opposite to shaft direction
-  if ( vtkMath::Dot( SHAFT_AXIS, toolTipToToolTranslation3_Shaft ) > 0 )
-  {
-    this->FlipShaftDirection();
-  }
-
+  this->ToolTipToToolMatrix->DeepCopy(matrix);
 }
 
 //---------------------------------------------------------------------------
 void vtkSlicerPivotCalibrationLogic::FlipShaftDirection()
 {
-  // Need to rotate around the orthogonal axis
-  vtkSmartPointer< vtkMatrix4x4 > rotationMatrix = vtkSmartPointer< vtkMatrix4x4 >::New();
-  this->GetToolTipToToolRotation( rotationMatrix );
+  vtkIGSIOAbstractStylusCalibrationAlgo::FlipShaftDirection(this->ToolTipToToolMatrix);
+}
 
-  double shaftAxis_Shaft[ 4 ] = { SHAFT_AXIS[ 0 ], SHAFT_AXIS[ 1 ], SHAFT_AXIS[ 2 ], 0 }; // This is a vector, not a point, so the last element is 0
-  double shaftAxis_ToolTip[ 4 ] = { 0, 0, 0, 0 };
-  rotationMatrix->MultiplyPoint( shaftAxis_Shaft, shaftAxis_ToolTip );
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetPivotNumberOfPoses()
+{
+  return this->Internal->PivotCalibrationAlgo->GetNumberOfCalibrationPoints();
+}
 
-  vnl_vector< double > orthogonalAxis_Shaft = this->ComputeSecondaryAxis( vnl_vector< double >( 3, 3, shaftAxis_ToolTip ) );
+//---------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetPivotMinimumOrientationDifferenceDegrees()
+{
+  return this->Internal->PivotCalibrationAlgo->GetMinimumOrientationDifferenceDegrees();
+}
 
-  vtkSmartPointer< vtkTransform > flipTransform = vtkSmartPointer< vtkTransform >::New();
-  flipTransform->RotateWXYZ( 180, orthogonalAxis_Shaft.get( 0 ), orthogonalAxis_Shaft.get( 1 ), orthogonalAxis_Shaft.get( 2 ) );
-  vtkSmartPointer< vtkTransform > originalTransform = vtkSmartPointer< vtkTransform >::New();
-  originalTransform->SetMatrix( this->ToolTipToToolMatrix );
-  originalTransform->PreMultiply();
-  originalTransform->Concatenate( flipTransform );
-  originalTransform->GetMatrix( this->ToolTipToToolMatrix );
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetPivotMinimumOrientationDifferenceDegrees(double minimumOrientationDifferenceDegrees)
+{
+  this->Internal->PivotCalibrationAlgo->SetMinimumOrientationDifferenceDegrees(minimumOrientationDifferenceDegrees);
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetPivotPoseBucketSize()
+{
+  return this->Internal->PivotCalibrationAlgo->GetPoseBucketSize();
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetPivotPoseBucketSize(int bucketSize)
+{
+  this->Internal->PivotCalibrationAlgo->SetPoseBucketSize(bucketSize);
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetPivotMaximumNumberOfPoseBuckets()
+{
+  return this->Internal->PivotCalibrationAlgo->GetMaximumNumberOfPoseBuckets();
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetPivotMaximumNumberOfPoseBuckets(int bucketSize)
+{
+  this->Internal->PivotCalibrationAlgo->SetMaximumNumberOfPoseBuckets(bucketSize);
+}
+
+//---------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetPivotMaximumPoseBucketError()
+{
+  return this->Internal->PivotCalibrationAlgo->GetMaximumPoseBucketError();
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetPivotMaximumPoseBucketError(double maximumBucketError)
+{
+  this->Internal->PivotCalibrationAlgo->SetMaximumPoseBucketError(maximumBucketError);
+}
+
+//-----------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetPivotPositionDifferenceThresholdMm()
+{
+  return this->Internal->PivotCalibrationAlgo->GetPositionDifferenceThresholdMm();
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetPivotPositionDifferenceThresholdMm(double thresholdMM)
+{
+  this->Internal->PivotCalibrationAlgo->SetPositionDifferenceThresholdMm(thresholdMM);
+}
+
+//-----------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetPivotOrientationDifferenceThresholdDegrees()
+{
+  return this->Internal->PivotCalibrationAlgo->GetOrientationDifferenceThresholdDegrees();
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetPivotOrientationDifferenceThresholdDegrees(double thresholdDegrees)
+{
+  this->Internal->PivotCalibrationAlgo->SetOrientationDifferenceThresholdDegrees(thresholdDegrees);
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetSpinNumberOfPoses()
+{
+  return this->Internal->SpinCalibrationAlgo->GetNumberOfCalibrationPoints();
+}
+
+//---------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetSpinMinimumOrientationDifferenceDegrees()
+{
+  return this->Internal->SpinCalibrationAlgo->GetMinimumOrientationDifferenceDegrees();
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetSpinMinimumOrientationDifferenceDegrees(double minimumOrientationDifferenceDegrees)
+{
+  this->Internal->SpinCalibrationAlgo->SetMinimumOrientationDifferenceDegrees(minimumOrientationDifferenceDegrees);
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetSpinPoseBucketSize()
+{
+  return this->Internal->SpinCalibrationAlgo->GetPoseBucketSize();
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetSpinPoseBucketSize(int bucketSize)
+{
+  this->Internal->SpinCalibrationAlgo->SetPoseBucketSize(bucketSize);
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerPivotCalibrationLogic::GetSpinMaximumNumberOfPoseBuckets()
+{
+  return this->Internal->SpinCalibrationAlgo->GetMaximumNumberOfPoseBuckets();
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetSpinMaximumNumberOfPoseBuckets(int bucketSize)
+{
+  this->Internal->SpinCalibrationAlgo->SetMaximumNumberOfPoseBuckets(bucketSize);
+}
+
+//---------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetSpinMaximumPoseBucketError()
+{
+  return this->Internal->SpinCalibrationAlgo->GetMaximumPoseBucketError();
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetSpinMaximumPoseBucketError(double maximumBucketError)
+{
+  this->Internal->SpinCalibrationAlgo->SetMaximumPoseBucketError(maximumBucketError);
+}
+
+//-----------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetSpinPositionDifferenceThresholdMm()
+{
+  return this->Internal->SpinCalibrationAlgo->GetPositionDifferenceThresholdMm();
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetSpinPositionDifferenceThresholdMm(double thresholdMM)
+{
+  this->Internal->SpinCalibrationAlgo->SetPositionDifferenceThresholdMm(thresholdMM);
+}
+
+//-----------------------------------------------------------------------------
+double vtkSlicerPivotCalibrationLogic::GetSpinOrientationDifferenceThresholdDegrees()
+{
+  return this->Internal->SpinCalibrationAlgo->GetOrientationDifferenceThresholdDegrees();
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerPivotCalibrationLogic::SetSpinOrientationDifferenceThresholdDegrees(double thresholdDegrees)
+{
+  this->Internal->SpinCalibrationAlgo->SetOrientationDifferenceThresholdDegrees(thresholdDegrees);
 }

--- a/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.h
+++ b/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.h
@@ -50,85 +50,216 @@ class VTK_SLICER_PIVOTCALIBRATION_MODULE_LOGIC_EXPORT vtkSlicerPivotCalibrationL
 {
 public:
 
-  static vtkSlicerPivotCalibrationLogic *New();
+  enum Events
+  {
+    InputTransformAdded = vtkCommand::UserEvent + 173,
+    PivotInputTransformAdded,
+    SpinInputTransformAdded,
+    PivotCalibrationCompleteEvent,
+    SpinCalibrationCompleteEvent
+  };
+
+  enum CalibrationErrorCodes
+  {
+    CALIBRATION_FAIL,
+    CALIBRATION_SUCCESS,
+    CALIBRATION_NOT_STARTED,
+    CALIBRATION_NOT_ENOUGH_POINTS,
+    CALIBRATION_NOT_ENOUGH_VARIATION,
+    CALIBRATION_HIGH_ERROR,
+  };
+
+  static vtkSlicerPivotCalibrationLogic* New();
   vtkTypeMacro(vtkSlicerPivotCalibrationLogic, vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Clears all previously acquired tool transforms.
   // Call this before start adding transforms.
   void ClearToolToReferenceMatrices();
+  void ClearPivotToolToReferenceMatrices();
+  void ClearSpinToolToReferenceMatrices();
 
   // Add a tool transforms automatically by observing transform changes
   vtkGetMacro(RecordingState, bool);
   vtkSetMacro(RecordingState, bool);
-  void SetAndObserveTransformNode( vtkMRMLLinearTransformNode* );
+  void SetAndObserveTransformNode(vtkMRMLLinearTransformNode*);
 
   // Add a single tool transform manually
-  void AddToolToReferenceMatrix( vtkMatrix4x4* );
+  void AddToolToReferenceMatrix(vtkMatrix4x4*);
 
   // Computes calibration results.
   // By default, automatically flips the shaft direction to be consistent with the needle orientation protocol.
   // Returns with false on failure
-  bool ComputePivotCalibration( bool autoOrient = true );
+  bool ComputePivotCalibration(bool autoOrient = true);
 
   // Computes calibration results.
   // By default, automatically flips the shaft direction to be consistent with the needle orientation protocol.
   // Optionally, snaps the rotation to be a 90 degree rotation about one of the coordinate axes.
   // Returns with false on failure
-  bool ComputeSpinCalibration( bool snapRotation = false, bool autoOrient = true ); // Note: The neede orientation protocol assumes that the shaft of the tool lies along the negative z-axis
+  bool ComputeSpinCalibration(bool snapRotation = false, bool autoOrient = true); // Note: The neede orientation protocol assumes that the shaft of the tool lies along the negative z-axis
 
   // Flip the direction of the shaft axis
   void FlipShaftDirection();
 
   // Get calibration results
-  void GetToolTipToToolTranslation( vtkMatrix4x4* );
-  void GetToolTipToToolRotation( vtkMatrix4x4* );
-  void GetToolTipToToolMatrix( vtkMatrix4x4* );
-  void SetToolTipToToolMatrix( vtkMatrix4x4* );
+  void GetToolTipToToolTranslation(vtkMatrix4x4*);
+  void GetToolTipToToolRotation(vtkMatrix4x4*);
+  void GetToolTipToToolMatrix(vtkMatrix4x4*);
+  void SetToolTipToToolMatrix(vtkMatrix4x4*);
+
   vtkGetMacro(PivotRMSE, double);
   vtkGetMacro(SpinRMSE, double);
 
   // Returns human-readable description of the error occurred (non-empty if ComputePivotCalibration returns with failure)
   vtkGetMacro(ErrorText, std::string);
-  
+
+  //@{
+  /// Returns the number of poses currently cached in the calibration algorithm
+  int GetPivotNumberOfPoses();
+  int GetSpinNumberOfPoses();
+  //@}
+
+  //@{
+  /// Returns the current error code in the calibration algorithm
+  int GetPivotErrorCode();
+  int GetSpinErrorCode();
+  //@}
+
+  /// Returns a human-readable string representing the specified error code
+  static std::string GetErrorCodeAsString(int code);
+
+  //@{
+  /// Flag that specifies if calibration should be automatically performed one the required number of poses has been reached.
+  /// If enough poses have been gathered and the error is below the threshold, then PivotCalibrationCompleteEvent or SpinCalibrationCompleteEvent will be invoked.
+  vtkGetMacro(PivotAutoCalibrationEnabled, bool);
+  vtkSetMacro(PivotAutoCalibrationEnabled, bool);
+  vtkBooleanMacro(PivotAutoCalibrationEnabled, bool);
+  vtkGetMacro(SpinAutoCalibrationEnabled, bool);
+  vtkSetMacro(SpinAutoCalibrationEnabled, bool);
+  vtkBooleanMacro(SpinAutoCalibrationEnabled, bool);
+  //@}
+
+  //@{
+  /// Flag that will specify if recording should be disabled when the desired threshold is reached.
+  /// Off by default.
+  vtkGetMacro(PivotAutoCalibrationStopWhenComplete, bool);
+  vtkSetMacro(PivotAutoCalibrationStopWhenComplete, bool);
+  vtkBooleanMacro(PivotAutoCalibrationStopWhenComplete, bool);
+  vtkGetMacro(SpinAutoCalibrationStopWhenComplete, bool);
+  vtkSetMacro(SpinAutoCalibrationStopWhenComplete, bool);
+  vtkBooleanMacro(SpinAutoCalibrationStopWhenComplete, bool);
+  //@}
+
+  //@{
+  /// The number of points required for automatic calibration.
+  vtkGetMacro(PivotAutoCalibrationTargetNumberOfPoints, int);
+  vtkSetMacro(PivotAutoCalibrationTargetNumberOfPoints, int);
+  vtkGetMacro(SpinAutoCalibrationTargetNumberOfPoints, int);
+  vtkSetMacro(SpinAutoCalibrationTargetNumberOfPoints, int);
+  //@}
+
+  //@{
+  /// The desired target error threshold for automatic calibration.
+  vtkGetMacro(PivotAutoCalibrationTargetError, double);
+  vtkSetMacro(PivotAutoCalibrationTargetError, double);
+  vtkGetMacro(SpinAutoCalibrationTargetError, double);
+  vtkSetMacro(SpinAutoCalibrationTargetError, double);
+  //@}
+
+  //@{
+  /// The number of poses that should be stored in each bucket.
+  /// When a bucket is filled, the algorithm will discard all saved poses if the error in the bucket is too high.
+  /// This indicates the fact that the tool is not performing the required motion.
+  int  GetPivotPoseBucketSize();
+  void SetPivotPoseBucketSize(int bucketSize);
+  int  GetSpinPoseBucketSize();
+  void SetSpinPoseBucketSize(int bucketSize);
+  //@}
+
+  //@{
+  /// The minimum required pose orientation difference among all input poses.
+  /// If the input variation is less than the threshold, then calibration will fail.
+  double GetPivotMinimumOrientationDifferenceDegrees();
+  void   SetPivotMinimumOrientationDifferenceDegrees(double);
+  double GetSpinMinimumOrientationDifferenceDegrees();
+  void   SetSpinMinimumOrientationDifferenceDegrees(double);
+  //@}
+
+  //@{
+  /// The maxmimum number of poses to maintain in the buffer.
+  /// If the number of buckets exceeds the maximum, then the oldest will be discarded.
+  int  GetPivotMaximumNumberOfPoseBuckets();
+  void SetPivotMaximumNumberOfPoseBuckets(int);
+  int  GetSpinMaximumNumberOfPoseBuckets();
+  void SetSpinMaximumNumberOfPoseBuckets(int);
+  //@}
+
+  //@{
+  /// The maximum amount of error that is allowed in a pose bucket.
+  /// When a bucket is filled, the algorithm will discard all saved poses if the error in the bucket is too high.
+  /// This indicates the fact that the tool is not performing the required motion.
+  double GetPivotMaximumPoseBucketError();
+  void   SetPivotMaximumPoseBucketError(double);
+  double GetSpinMaximumPoseBucketError();
+  void   SetSpinMaximumPoseBucketError(double);
+  //@}
+
+  //@{
+  /// The minimum required amount of translation of the input transform from the previous pose.
+  /// If the translation is less than the specified amount, then the pose will not be added to the buffer.
+  double GetPivotPositionDifferenceThresholdMm();
+  void   SetPivotPositionDifferenceThresholdMm(double);
+  double GetSpinPositionDifferenceThresholdMm();
+  void   SetSpinPositionDifferenceThresholdMm(double);
+  //@}
+
+  //@{
+  /// The minimum required amount of rotation of the input transform from the previous pose.
+  /// If the rotation is less than the specified amount, then the pose will not be added to the buffer.
+  double GetPivotOrientationDifferenceThresholdDegrees();
+  void   SetPivotOrientationDifferenceThresholdDegrees(double);
+  double GetSpinOrientationDifferenceThresholdDegrees();
+  void   SetSpinOrientationDifferenceThresholdDegrees(double);
+  //@}
+
 protected:
   vtkSlicerPivotCalibrationLogic();
   virtual ~vtkSlicerPivotCalibrationLogic();
-  
+
   void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData ) override;
 
-  // Returns the orientation difference in degrees between two 4x4 homogeneous transformation matrix, in degrees.
-  double GetOrientationDifferenceDeg(vtkMatrix4x4* aMatrix, vtkMatrix4x4* bMatrix);
-  
-  // Computes the maximum orientation difference in degrees between the first tool transformation
-  // and all the others. Used for determining if there was enough variation in the input data.
-  double GetMaximumToolOrientationDifferenceDeg();
+  static void ProcessPivotCalibrationAlgorithmEvents(vtkObject* caller, unsigned long event, void* clientData, void* callData);
 
-  // Verify whether the tool's shaft is in the same direction as the ToolTip to Tool vector.
-  // Rotate the ToolTip coordinate frame by 180 degrees about the secondary axis to make the 
-  // shaft in the same direction as the ToolTip to Tool vector, if this is not already the case.
-  void UpdateShaftDirection();
+  vtkSetMacro(PivotRMSE, double);
+  vtkSetMacro(SpinRMSE, double);
 
-  // Helper method to compute the secondary axis, given a shaft axis
-  static vnl_vector< double > ComputeSecondaryAxis( vnl_vector< double > shaftAxis_ToolTip );
+  class vtkInternal;
+  vtkInternal* Internal;
 
-  
 private:
 
   vtkSlicerPivotCalibrationLogic(const vtkSlicerPivotCalibrationLogic&); // Not implemented
   void operator=(const vtkSlicerPivotCalibrationLogic&);               // Not implemented
 
   // Calibration inputs
-  double MinimumOrientationDifferenceDeg;
-  std::vector< vtkMatrix4x4* > ToolToReferenceMatrices;
-  vtkMRMLLinearTransformNode* ObservedTransformNode;
-  bool RecordingState;
+  vtkMRMLLinearTransformNode* ObservedTransformNode{nullptr};
+  bool RecordingState{false};
 
   // Calibration results
   vtkMatrix4x4* ToolTipToToolMatrix;
   double PivotRMSE;
-  double SpinRMSE; 
+  double SpinRMSE;
   std::string ErrorText;
+
+  double PivotAutoCalibrationTargetError{ 3.0 };
+  int    PivotAutoCalibrationTargetNumberOfPoints{ 50 };
+  bool   PivotAutoCalibrationStopWhenComplete{ false };
+  bool   PivotAutoCalibrationEnabled{ false };
+
+  double SpinAutoCalibrationTargetError{ 3.0 };
+  int    SpinAutoCalibrationTargetNumberOfPoints{ 50 };
+  bool   SpinAutoCalibrationStopWhenComplete{ false };
+  bool   SpinAutoCalibrationEnabled{ false };
 };
 
 #endif

--- a/PivotCalibration/Testing/Cxx/CMakeLists.txt
+++ b/PivotCalibration/Testing/Cxx/CMakeLists.txt
@@ -1,17 +1,38 @@
 set(KIT qSlicer${MODULE_NAME}Module)
 
+#-----------------------------------------------------------------------------
 set(KIT_TEST_SRCS
   vtkPivotCalibrationTest.cxx
   )
-
-include_directories( ${CMAKE_CURRENT_BINARY_DIR} )
-
-#-----------------------------------------------------------------------------
-slicerMacroConfigureModuleCxxTestDriver(
-  NAME ${KIT}
-  SOURCES ${KIT_TEST_SRCS}
-  WITH_VTK_DEBUG_LEAKS_CHECK
-  WITH_VTK_ERROR_OUTPUT_CHECK
+set(KIT_TEST_NAMES
+  vtkPivotCalibrationTest
+  )
+set(KIT_TEST_NAMES_CXX
+  vtkPivotCalibrationTest
   )
 
-simple_test(vtkPivotCalibrationTest)
+SlicerMacroConfigureGenericCxxModuleTests(${MODULE_NAME} KIT_TEST_SRCS KIT_TEST_NAMES KIT_TEST_NAMES_CXX)
+
+#-----------------------------------------------------------------------------
+#set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "DEBUG_LEAKS_ENABLE_EXIT_ERROR();" )
+create_test_sourcelist(Tests ${KIT}CxxTests.cxx
+  ${KIT_TEST_NAMES_CXX}
+  # Add source of your tests after this line.
+  #EXTRA_INCLUDE vtkMRMLDebugLeaksMacro.h
+  )
+list(REMOVE_ITEM Tests ${KIT_TEST_NAMES_CXX})
+list(APPEND Tests ${KIT_TEST_SRCS})
+
+#-----------------------------------------------------------------------------
+add_executable(${KIT}CxxTests ${Tests})
+target_link_libraries(${KIT}CxxTests ${KIT})
+
+#-----------------------------------------------------------------------------
+set(PATH_STRING "$ENV{PATH}")
+STRING(REPLACE "\\;" ";" PATH_STRING "${PATH_STRING}")
+STRING(REPLACE ";" "\\;" PATH_STRING "${PATH_STRING}")
+foreach(testname ${KIT_TEST_NAMES})
+  SIMPLE_TEST( ${testname} )
+  SET_TESTS_PROPERTIES(${testname}
+    PROPERTIES ENVIRONMENT "PATH=${PATH_STRING}")
+endforeach()


### PR DESCRIPTION
This commit changes the internal logic of vtkSlicerPivotCalibrationLogic to use the pivot and spin calibration algorithms from IGSIO.

This also provides access to the option to enable automatic calibration from Python. During automatic calibration, the buffer will be filled as the tool moves. If invalid tool motion is detected due to high error in recent poses, then the whole input buffer will be discarded. Once the required number of poses and error threshold is reached, vtkSlicerPivotCalibrationLogic will invoke (Pivot/Spin)CalibrationCompleteEvent. These options are currently not accessible through the GUI.