### PR TITLE
ENH: Add UI for performing stylus auto-calibration

### DIFF
--- a/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.h
+++ b/PivotCalibration/Logic/vtkSlicerPivotCalibrationLogic.h
@@ -25,17 +25,11 @@
 
 // VTK includes
 #include <vtkMatrix4x4.h>
-#include <vtkMath.h>
 
 // MRML includes
 #include "vtkMRMLLinearTransformNode.h"
 
-// STD includes
-#include <cstdlib>
-
-// VNL includes
-#include "vnl/vnl_matrix.h"
-
+// Pivot calibration includes
 #include "vtkSlicerPivotCalibrationModuleLogicExport.h"
 
 
@@ -132,11 +126,24 @@ public:
   /// Flag that specifies if calibration should be automatically performed one the required number of poses has been reached.
   /// If enough poses have been gathered and the error is below the threshold, then PivotCalibrationCompleteEvent or SpinCalibrationCompleteEvent will be invoked.
   vtkGetMacro(PivotAutoCalibrationEnabled, bool);
-  vtkSetMacro(PivotAutoCalibrationEnabled, bool);
+  void SetPivotAutoCalibrationEnabled(bool);
   vtkBooleanMacro(PivotAutoCalibrationEnabled, bool);
   vtkGetMacro(SpinAutoCalibrationEnabled, bool);
-  vtkSetMacro(SpinAutoCalibrationEnabled, bool);
+  void SetSpinAutoCalibrationEnabled(bool);
   vtkBooleanMacro(SpinAutoCalibrationEnabled, bool);
+  //@}
+
+  //@{
+  /// Flag that specifies if calibration is enabled for the specified type.
+  /// If on, poses will be added to the calibration algorithm as the transform is modified.
+  /// If off, poses will not be added to the calibration algorithm.
+  /// Option is on by default.
+  vtkGetMacro(PivotCalibrationEnabled, bool);
+  vtkSetMacro(PivotCalibrationEnabled, bool);
+  vtkBooleanMacro(PivotCalibrationEnabled, bool);
+  vtkGetMacro(SpinCalibrationEnabled, bool);
+  vtkSetMacro(SpinCalibrationEnabled, bool);
+  vtkBooleanMacro(SpinCalibrationEnabled, bool);
   //@}
 
   //@{
@@ -161,9 +168,9 @@ public:
   //@{
   /// The desired target error threshold for automatic calibration.
   vtkGetMacro(PivotAutoCalibrationTargetError, double);
-  vtkSetMacro(PivotAutoCalibrationTargetError, double);
+  void SetPivotAutoCalibrationTargetError(double);
   vtkGetMacro(SpinAutoCalibrationTargetError, double);
-  vtkSetMacro(SpinAutoCalibrationTargetError, double);
+  void SetSpinAutoCalibrationTargetError(double);
   //@}
 
   //@{
@@ -226,9 +233,7 @@ protected:
   vtkSlicerPivotCalibrationLogic();
   virtual ~vtkSlicerPivotCalibrationLogic();
 
-  void ProcessMRMLNodesEvents( vtkObject* caller, unsigned long event, void* callData ) override;
-
-  static void ProcessPivotCalibrationAlgorithmEvents(vtkObject* caller, unsigned long event, void* clientData, void* callData);
+  void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* callData) override;
 
   vtkSetMacro(PivotRMSE, double);
   vtkSetMacro(SpinRMSE, double);
@@ -242,24 +247,30 @@ private:
   void operator=(const vtkSlicerPivotCalibrationLogic&);               // Not implemented
 
   // Calibration inputs
-  vtkMRMLLinearTransformNode* ObservedTransformNode{nullptr};
-  bool RecordingState{false};
+  vtkMRMLLinearTransformNode* ObservedTransformNode{ nullptr };
+  bool RecordingState{ false };
 
   // Calibration results
   vtkMatrix4x4* ToolTipToToolMatrix;
-  double PivotRMSE;
-  double SpinRMSE;
+  double PivotRMSE{ -1.0 };
+  double SpinRMSE{ -1.0 };
   std::string ErrorText;
 
-  double PivotAutoCalibrationTargetError{ 3.0 };
-  int    PivotAutoCalibrationTargetNumberOfPoints{ 50 };
-  bool   PivotAutoCalibrationStopWhenComplete{ false };
-  bool   PivotAutoCalibrationEnabled{ false };
+  // Pivot/spin enabled flags
+  bool   PivotCalibrationEnabled{ true };
+  bool   SpinCalibrationEnabled{ true };
 
-  double SpinAutoCalibrationTargetError{ 3.0 };
-  int    SpinAutoCalibrationTargetNumberOfPoints{ 50 };
-  bool   SpinAutoCalibrationStopWhenComplete{ false };
+  // Pivot auto-calibration settings
+  bool   PivotAutoCalibrationEnabled{ false };
+  double PivotAutoCalibrationTargetError{ 3.0 };
+  int    PivotAutoCalibrationTargetNumberOfPoints{ 100 };
+  bool   PivotAutoCalibrationStopWhenComplete{ false };
+
+  // Spin auto-calibration settings
   bool   SpinAutoCalibrationEnabled{ false };
+  double SpinAutoCalibrationTargetError{ 0.01 };
+  int    SpinAutoCalibrationTargetNumberOfPoints{ 100 };
+  bool   SpinAutoCalibrationStopWhenComplete{ false };
 };
 
 #endif

--- a/PivotCalibration/Resources/UI/qSlicerPivotCalibrationModule.ui
+++ b/PivotCalibration/Resources/UI/qSlicerPivotCalibrationModule.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>492</width>
-    <height>767</height>
+    <width>302</width>
+    <height>446</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,7 +38,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Input (ToolToReference)</string>
+         <string>Input (ToolToReference):</string>
         </property>
        </widget>
       </item>
@@ -54,7 +54,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Output (ToolTipToTool)</string>
+         <string>Output (ToolTipToTool):</string>
         </property>
        </widget>
       </item>
@@ -80,138 +80,278 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Startup delay (seconds):  </string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkDoubleSpinBox" name="startupTimerEdit">
-          <property name="decimals">
-           <number>0</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>30.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout1">
-        <item>
-         <widget class="QLabel" name="label_31">
-          <property name="text">
-           <string>Delay and duration (seconds):  </string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkDoubleSpinBox" name="durationTimerEdit">
-          <property name="decimals">
-           <number>0</number>
-          </property>
-          <property name="minimum">
-           <double>3.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>60.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_5">
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>Data collection will start and end after specified time.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="startPivotButton">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start collecting data for pivot calibration. The calibration will be computed and orientation will be appropriately flipped on completion.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Start Pivot Calibration</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="startSpinButton">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start collecting data for spin calibration. The calibration will be computed and orientation will be appropriately flipped on completion.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Start Spin Calibration</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="ctkCollapsibleGroupBox" name="settingsGroupBox">
+       <widget class="QTabWidget" name="tabWidget">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="title">
-         <string>Settings</string>
+        <property name="currentIndex">
+         <number>0</number>
         </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="collapsed">
-         <bool>true</bool>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <widget class="QCheckBox" name="snapCheckBox">
-           <property name="toolTip">
-            <string>Force snap the tool's orientation to be along the closest coordinate axis.</string>
-           </property>
-           <property name="text">
-            <string>Snap rotation to right-angle</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="flipButton">
-           <property name="toolTip">
-            <string>If the tool points in the wrong direction, flip it to point in the opposite direction.</string>
-           </property>
-           <property name="text">
-            <string>Flip</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="CountdownLabel">
-        <property name="text">
-         <string>Countdown</string>
-        </property>
+        <widget class="QWidget" name="manualCalibrationTab">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <attribute name="title">
+          <string>Manual</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Startup delay (seconds):  </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ctkDoubleSpinBox" name="startupTimerEdit">
+              <property name="decimals">
+               <number>0</number>
+              </property>
+              <property name="minimum">
+               <double>0.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>30.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>5.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout1">
+            <item>
+             <widget class="QLabel" name="label_31">
+              <property name="text">
+               <string>Delay and duration (seconds):  </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ctkDoubleSpinBox" name="durationTimerEdit">
+              <property name="decimals">
+               <number>0</number>
+              </property>
+              <property name="minimum">
+               <double>3.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>60.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>5.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_5">
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Data collection will start and end after specified time.</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="startPivotButton">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start collecting data for pivot calibration. The calibration will be computed and orientation will be appropriately flipped on completion.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Start Pivot Calibration</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="startSpinButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start collecting data for spin calibration. The calibration will be computed and orientation will be appropriately flipped on completion.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Start Spin Calibration</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="CountdownLabel">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Countdown</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="autoCalibrationTab">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <attribute name="title">
+          <string>Auto</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_7">
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="spinAutoCalibrationButton">
+            <property name="text">
+             <string>Spin auto-calibrate</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="spinResetButton">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QPushButton" name="pivotResetButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QProgressBar" name="pivotCalibrationProgressBar">
+            <property name="value">
+             <number>0</number>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="textVisible">
+             <bool>true</bool>
+            </property>
+            <property name="invertedAppearance">
+             <bool>false</bool>
+            </property>
+            <property name="textDirection">
+             <enum>QProgressBar::TopToBottom</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QCheckBox" name="spinAutoStopCheckBox">
+            <property name="text">
+             <string>Stop when complete</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="pivotAutoStopCheckBox">
+            <property name="text">
+             <string>Stop when complete</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QProgressBar" name="spinCalibrationProgressBar">
+            <property name="value">
+             <number>0</number>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="textVisible">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QPushButton" name="pivotAutoCalibrationButton">
+            <property name="text">
+             <string>Pivot auto-calibrate</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
      </layout>
@@ -263,6 +403,451 @@
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton">
+     <property name="text">
+      <string>Settings</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="QCheckBox" name="snapCheckBox">
+        <property name="toolTip">
+         <string>Force snap the tool's orientation to be along the closest coordinate axis.</string>
+        </property>
+        <property name="text">
+         <string>Snap rotation to right-angle</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="flipButton">
+        <property name="toolTip">
+         <string>If the tool points in the wrong direction, flip it to point in the opposite direction.</string>
+        </property>
+        <property name="text">
+         <string>Flip</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_5">
+        <property name="title">
+         <string>Pivot input validation</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="1" column="1">
+          <widget class="ctkDoubleSpinBox" name="pivotInputOrientationDifferenceThresholdSpinBox">
+           <property name="toolTip">
+            <string>Minimum required orientation difference from previous pose during pivot calibration</string>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="maximum">
+            <double>180.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="ctkDoubleSpinBox" name="pivotInputMinPositionDifferenceSpinBox">
+           <property name="toolTip">
+            <string>Minimum required position difference from previous pose during pivot calibration</string>
+           </property>
+           <property name="suffix">
+            <string>mm</string>
+           </property>
+           <property name="maximum">
+            <double>9999.989999999999782</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_13">
+           <property name="text">
+            <string>Minimum position difference:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_20">
+           <property name="text">
+            <string>Minimum orientation difference:</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_6">
+        <property name="title">
+         <string>Spin input validation</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_6">
+         <item row="2" column="1">
+          <widget class="ctkDoubleSpinBox" name="spinInputMinPositionDifferenceSpinBox">
+           <property name="toolTip">
+            <string>Minimum required position difference from previous pose during spin calibration</string>
+           </property>
+           <property name="suffix">
+            <string>mm</string>
+           </property>
+           <property name="maximum">
+            <double>9999.989999999999782</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="ctkDoubleSpinBox" name="spinInputOrientationDifferenceThresholdSpinBox">
+           <property name="toolTip">
+            <string>Minimum required orientation difference from previous pose during spin calibration</string>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="maximum">
+            <double>180.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Minimum orientation difference:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_19">
+           <property name="text">
+            <string>Maximum position difference:</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkCollapsibleGroupBox" name="autoPivotGroupBox">
+        <property name="title">
+         <string>Pivot auto-calibration settings</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <property name="leftMargin">
+          <number>3</number>
+         </property>
+         <property name="topMargin">
+          <number>3</number>
+         </property>
+         <property name="rightMargin">
+          <number>3</number>
+         </property>
+         <property name="bottomMargin">
+          <number>3</number>
+         </property>
+         <item>
+          <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_3">
+           <property name="title">
+            <string>Completion</string>
+           </property>
+           <property name="collapsed">
+            <bool>false</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="pivotTargetPointSpinBox">
+              <property name="toolTip">
+               <string>Number of collected poses for pivot auto-calibration</string>
+              </property>
+              <property name="maximum">
+               <number>999999999</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="ctkDoubleSpinBox" name="pivotTargetErrorSpinBox">
+              <property name="toolTip">
+               <string>Minimum error for pivot auto-calibration to be successful</string>
+              </property>
+              <property name="suffix">
+               <string>mm</string>
+              </property>
+              <property name="maximum">
+               <double>9999.989999999999782</double>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>Target error:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_6">
+              <property name="text">
+               <string>Target number of points:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="ctkDoubleSpinBox" name="pivotMinOrientationDifferenceSpinBox">
+              <property name="toolTip">
+               <string>Minimum orientation difference in collected poses for pivot auto-calibration to be successful</string>
+              </property>
+              <property name="suffix">
+               <string>°</string>
+              </property>
+              <property name="maximum">
+               <double>180.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_10">
+              <property name="text">
+               <string>Minimum orientation difference:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_4">
+           <property name="title">
+            <string>Buffer</string>
+           </property>
+           <property name="collapsed">
+            <bool>false</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_5">
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Maximum number of buckets:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_9">
+              <property name="text">
+               <string>Bucket size:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="pivotMaxBucketSpinBox">
+              <property name="toolTip">
+               <string>Maximum number of buckets to create for pivot auto-calibration</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_12">
+              <property name="text">
+               <string>Maximum bucket error:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="qMRMLSpinBox" name="pivotMaxBucketError">
+              <property name="toolTip">
+               <string>Maximum error allowed within a bucket. All buckets are discarded if this threshold is exceeded</string>
+              </property>
+              <property name="suffix">
+               <string>mm</string>
+              </property>
+              <property name="maximum">
+               <double>999999999999999949387135297074018866963645011013410073083904.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="pivotBucketSizeSpinBox">
+              <property name="toolTip">
+               <string>Number of poses to hold in each pivot auto-calibration bucket</string>
+              </property>
+              <property name="maximum">
+               <number>999999999</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkCollapsibleGroupBox" name="autoSpinGroupBox">
+        <property name="title">
+         <string>Spin auto-calibration settings</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_7">
+         <property name="leftMargin">
+          <number>3</number>
+         </property>
+         <property name="topMargin">
+          <number>3</number>
+         </property>
+         <property name="rightMargin">
+          <number>3</number>
+         </property>
+         <property name="bottomMargin">
+          <number>3</number>
+         </property>
+         <item>
+          <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox">
+           <property name="title">
+            <string>Completion</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_14">
+              <property name="text">
+               <string>Target error:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="ctkDoubleSpinBox" name="spinTargetErrorSpinBox">
+              <property name="toolTip">
+               <string>Minimum error for spin auto-calibration to be successful</string>
+              </property>
+              <property name="suffix">
+               <string>mm</string>
+              </property>
+              <property name="maximum">
+               <double>9999.989999999999782</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Target number of points:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="spinTargetPointSpinBox">
+              <property name="toolTip">
+               <string>Number of collected poses for spin auto-calibration</string>
+              </property>
+              <property name="maximum">
+               <number>999999999</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="ctkDoubleSpinBox" name="spinMinOrientationDifferenceSpinBox">
+              <property name="toolTip">
+               <string>Minimum orientation difference in collected poses for spin auto-calibration to be successful</string>
+              </property>
+              <property name="suffix">
+               <string>°</string>
+              </property>
+              <property name="maximum">
+               <double>180.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_21">
+              <property name="text">
+               <string>Minimum orientation difference:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_2">
+           <property name="title">
+            <string>Buffer</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_17">
+              <property name="text">
+               <string>Maximum bucket error:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>Maximum number of buckets:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_16">
+              <property name="text">
+               <string>Bucket size:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="ctkDoubleSpinBox" name="spinMaxBucketError">
+              <property name="toolTip">
+               <string>Maximum error allowed within a bucket. All buckets are discarded if this threshold is exceeded</string>
+              </property>
+              <property name="suffix">
+               <string>mm</string>
+              </property>
+              <property name="maximum">
+               <double>99999999999.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="spinBucketSizeSpinBox">
+              <property name="toolTip">
+               <string>Number of poses to hold in each pivot auto-calibration bucket</string>
+              </property>
+              <property name="maximum">
+               <number>99999</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="spinMaxBucketSpinBox">
+              <property name="toolTip">
+               <string>Maximum number of buckets to create for spin auto-calibration</string>
+              </property>
+              <property name="maximum">
+               <number>99999</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -283,6 +868,11 @@
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSpinBox</class>
+   <extends>ctkDoubleSpinBox</extends>
+   <header>qMRMLSpinBox.h</header>
   </customwidget>
   <customwidget>
    <class>qSlicerWidget</class>

--- a/PivotCalibration/qSlicerPivotCalibrationModuleWidget.cxx
+++ b/PivotCalibration/qSlicerPivotCalibrationModuleWidget.cxx
@@ -34,13 +34,13 @@
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_ExtensionTemplate
-class qSlicerPivotCalibrationModuleWidgetPrivate: public Ui_qSlicerPivotCalibrationModule
+class qSlicerPivotCalibrationModuleWidgetPrivate : public Ui_qSlicerPivotCalibrationModule
 {
-  Q_DECLARE_PUBLIC( qSlicerPivotCalibrationModuleWidget );
+  Q_DECLARE_PUBLIC(qSlicerPivotCalibrationModuleWidget);
 protected:
   qSlicerPivotCalibrationModuleWidget* const q_ptr;
 public:
-  qSlicerPivotCalibrationModuleWidgetPrivate( qSlicerPivotCalibrationModuleWidget& object );
+  qSlicerPivotCalibrationModuleWidgetPrivate(qSlicerPivotCalibrationModuleWidget& object);
   vtkSlicerPivotCalibrationLogic* logic() const;
 };
 
@@ -48,46 +48,40 @@ public:
 // qSlicerPivotCalibrationModuleWidgetPrivate methods
 
 //-----------------------------------------------------------------------------
-qSlicerPivotCalibrationModuleWidgetPrivate::qSlicerPivotCalibrationModuleWidgetPrivate( qSlicerPivotCalibrationModuleWidget& object )
- : q_ptr( &object )
+qSlicerPivotCalibrationModuleWidgetPrivate::qSlicerPivotCalibrationModuleWidgetPrivate(qSlicerPivotCalibrationModuleWidget& object)
+  : q_ptr(&object)
 {
 }
 
-
+//-----------------------------------------------------------------------------
 vtkSlicerPivotCalibrationLogic* qSlicerPivotCalibrationModuleWidgetPrivate::logic() const
 {
-  Q_Q( const qSlicerPivotCalibrationModuleWidget );
-  return vtkSlicerPivotCalibrationLogic::SafeDownCast( q->logic() );
+  Q_Q(const qSlicerPivotCalibrationModuleWidget);
+  return vtkSlicerPivotCalibrationLogic::SafeDownCast(q->logic());
 }
-
 
 //-----------------------------------------------------------------------------
 // qSlicerPivotCalibrationModuleWidget methods
 //-----------------------------------------------------------------------------
-qSlicerPivotCalibrationModuleWidget::qSlicerPivotCalibrationModuleWidget(QWidget* _parent) : Superclass( _parent ) , d_ptr( new qSlicerPivotCalibrationModuleWidgetPrivate(*this))
+qSlicerPivotCalibrationModuleWidget::qSlicerPivotCalibrationModuleWidget(QWidget* _parent)
+  : Superclass(_parent)
+  , d_ptr(new qSlicerPivotCalibrationModuleWidgetPrivate(*this))
 {
-  this->startupDurationSec = 5;
-  this->samplingDurationSec = 5;
-
   this->pivotStartupTimer = new QTimer();
-  pivotStartupTimer->setSingleShot(false);
-  pivotStartupTimer->setInterval(1000); // 1 sec
-  this->pivotStartupRemainingTimerPeriodCount = 0;
+  this->pivotStartupTimer->setSingleShot(false);
+  this->pivotStartupTimer->setInterval(1000); // 1 sec
 
   this->pivotSamplingTimer = new QTimer();
-  pivotSamplingTimer->setSingleShot(false);
-  pivotSamplingTimer->setInterval(1000); // 1 sec
-  this->pivotSamplingRemainingTimerPeriodCount = 0;
+  this->pivotSamplingTimer->setSingleShot(false);
+  this->pivotSamplingTimer->setInterval(1000); // 1 sec
 
   this->spinStartupTimer = new QTimer();
-  spinStartupTimer->setSingleShot(false);
-  spinStartupTimer->setInterval(1000); // 1 sec
-  this->spinStartupRemainingTimerPeriodCount = 0;
+  this->spinStartupTimer->setSingleShot(false);
+  this->spinStartupTimer->setInterval(1000); // 1 sec
 
   this->spinSamplingTimer = new QTimer();
-  spinSamplingTimer->setSingleShot(false);
-  spinSamplingTimer->setInterval(1000); // 1 sec
-  this->spinSamplingRemainingTimerPeriodCount = 0;
+  this->spinSamplingTimer->setSingleShot(false);
+  this->spinSamplingTimer->setInterval(1000); // 1 sec
 }
 
 //-----------------------------------------------------------------------------
@@ -110,8 +104,8 @@ void qSlicerPivotCalibrationModuleWidget::initializeObserver(vtkMRMLNode* node)
 {
   Q_D(qSlicerPivotCalibrationModuleWidget);
 
-  vtkMRMLLinearTransformNode* transformNode = vtkMRMLLinearTransformNode::SafeDownCast( node );
-  d->logic()->SetAndObserveTransformNode( transformNode );
+  vtkMRMLLinearTransformNode* transformNode = vtkMRMLLinearTransformNode::SafeDownCast(node);
+  d->logic()->SetAndObserveTransformNode(transformNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -122,20 +116,68 @@ void qSlicerPivotCalibrationModuleWidget::setup()
 
   this->Superclass::setup();
 
-  connect(pivotStartupTimer, SIGNAL( timeout() ), this, SLOT( onPivotStartupTimeout() ));
-  connect(pivotSamplingTimer, SIGNAL( timeout() ), this, SLOT( onPivotSamplingTimeout() ));
-  connect(spinStartupTimer, SIGNAL( timeout() ), this, SLOT( onSpinStartupTimeout() ));
-  connect(spinSamplingTimer, SIGNAL( timeout() ), this, SLOT( onSpinSamplingTimeout() ));
+  // Tab widget connections
+  connect(d->tabWidget, SIGNAL(currentChanged(int)), this, SLOT(updateLogicFromWidget()));
 
-  connect( d->InputComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)), this, SLOT(initializeObserver(vtkMRMLNode*)) );
+  // Manual calibration connections
+  connect(pivotStartupTimer, SIGNAL(timeout()), this, SLOT(onPivotStartupTimeout()));
+  connect(pivotSamplingTimer, SIGNAL(timeout()), this, SLOT(onPivotSamplingTimeout()));
+  connect(spinStartupTimer, SIGNAL(timeout()), this, SLOT(onSpinStartupTimeout()));
+  connect(spinSamplingTimer, SIGNAL(timeout()), this, SLOT(onSpinSamplingTimeout()));
 
-  connect( d->startPivotButton, SIGNAL( clicked() ), this, SLOT( onStartPivotPart() ) );
-  connect( d->startSpinButton, SIGNAL( clicked() ), this, SLOT( onStartSpinPart() ) );
+  connect(d->InputComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)), this, SLOT(initializeObserver(vtkMRMLNode*)));
 
-  connect( d->startupTimerEdit, SIGNAL( valueChanged(double) ), this, SLOT( setStartupDurationSec(double) ) );
-  connect( d->durationTimerEdit, SIGNAL( valueChanged(double) ), this, SLOT( setSamplingDurationSec(double) ) );
+  connect(d->startPivotButton, SIGNAL(clicked()), this, SLOT(onStartPivotPart()));
+  connect(d->startSpinButton, SIGNAL(clicked()), this, SLOT(onStartSpinPart()));
 
-  connect( d->flipButton, SIGNAL( clicked() ), this, SLOT( onFlipButtonClicked() ) );
+  connect(d->startupTimerEdit, SIGNAL(valueChanged(double)), this, SLOT(setStartupDurationSec(double)));
+  connect(d->durationTimerEdit, SIGNAL(valueChanged(double)), this, SLOT(setSamplingDurationSec(double)));
+
+  connect(d->flipButton, SIGNAL(clicked()), this, SLOT(onFlipButtonClicked()));
+
+  // Auto calibration connections
+
+  // Pivot calibration settings
+  connect(d->pivotTargetPointSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateLogicFromWidget()));
+  connect(d->pivotTargetErrorSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+  connect(d->pivotMinOrientationDifferenceSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+
+  connect(d->pivotAutoCalibrationButton, SIGNAL(clicked()), this, SLOT(updateLogicFromWidget()));
+  connect(d->pivotAutoStopCheckBox, SIGNAL(clicked()), this, SLOT(updateLogicFromWidget()));
+  connect(d->pivotResetButton, SIGNAL(clicked()), this, SLOT(onPivotResetButtonClicked()));
+
+  connect(d->pivotBucketSizeSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateLogicFromWidget()));
+  connect(d->pivotMaxBucketSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateLogicFromWidget()));
+  connect(d->pivotMaxBucketError, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+
+  connect(d->pivotInputOrientationDifferenceThresholdSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+  connect(d->pivotInputMinPositionDifferenceSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+
+  // Spin calibration settings
+  connect(d->spinTargetPointSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateLogicFromWidget()));
+  connect(d->spinTargetErrorSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+  connect(d->spinMinOrientationDifferenceSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+
+  connect(d->spinAutoCalibrationButton, SIGNAL(clicked()), this, SLOT(updateLogicFromWidget()));
+  connect(d->spinAutoStopCheckBox, SIGNAL(clicked()), this, SLOT(updateLogicFromWidget()));
+  connect(d->spinResetButton, SIGNAL(clicked()), this, SLOT(onSpinResetButtonClicked()));
+
+  connect(d->spinBucketSizeSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateLogicFromWidget()));
+  connect(d->spinMaxBucketSpinBox, SIGNAL(valueChanged(int)), this, SLOT(updateLogicFromWidget()));
+  connect(d->spinMaxBucketError, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+
+  connect(d->spinInputOrientationDifferenceThresholdSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+  connect(d->spinInputMinPositionDifferenceSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateLogicFromWidget()));
+
+  // Logic observers
+  qvtkConnect(this->logic(), vtkCommand::ModifiedEvent, this, SLOT(updateWidgetFromLogic()));
+  qvtkConnect(this->logic(), vtkSlicerPivotCalibrationLogic::InputTransformAdded, this, SLOT(updateWidgetFromLogic()));
+  qvtkConnect(this->logic(), vtkSlicerPivotCalibrationLogic::PivotInputTransformAdded, this, SLOT(updateWidgetFromLogic()));
+  qvtkConnect(this->logic(), vtkSlicerPivotCalibrationLogic::SpinInputTransformAdded, this, SLOT(updateWidgetFromLogic()));
+  qvtkConnect(this->logic(), vtkSlicerPivotCalibrationLogic::PivotCalibrationCompleteEvent, this, SLOT(onPivotAutoCalibrationComplete()));
+  qvtkConnect(this->logic(), vtkSlicerPivotCalibrationLogic::SpinCalibrationCompleteEvent, this, SLOT(onSpinAutoCalibrationComplete()));
+
+  this->updateWidgetFromLogic();
 }
 
 //-----------------------------------------------------------------------------
@@ -150,7 +192,9 @@ void qSlicerPivotCalibrationModuleWidget::onStartPivotPart()
   ss << this->pivotStartupRemainingTimerPeriodCount << " seconds until start";
   d->CountdownLabel->setText(ss.str().c_str());
 
-  pivotStartupTimer->start();
+  this->pivotStartupTimer->start();
+
+  this->updateWidgetFromLogic();
 }
 
 //-----------------------------------------------------------------------------
@@ -165,9 +209,10 @@ void qSlicerPivotCalibrationModuleWidget::onStartSpinPart()
   ss << this->spinStartupRemainingTimerPeriodCount << " seconds until start";
   d->CountdownLabel->setText(ss.str().c_str());
 
-  spinStartupTimer->start();
-}
+  this->spinStartupTimer->start();
 
+  this->updateWidgetFromLogic();
+}
 
 //-----------------------------------------------------------------------------
 void qSlicerPivotCalibrationModuleWidget::onPivotStartupTimeout()
@@ -188,6 +233,9 @@ void qSlicerPivotCalibrationModuleWidget::onPivotStartupTimeout()
     d->CountdownLabel->setText(ss2.str().c_str());
 
     this->pivotStartupTimer->stop();
+    d->logic()->SetPivotCalibrationEnabled(true);
+    d->logic()->SetSpinCalibrationEnabled(false);
+    d->logic()->ClearPivotToolToReferenceMatrices();
     d->logic()->SetRecordingState(true);
     this->pivotSamplingTimer->start();
   }
@@ -233,6 +281,9 @@ void qSlicerPivotCalibrationModuleWidget::onSpinStartupTimeout()
     d->CountdownLabel->setText(ss2.str().c_str());
 
     this->spinStartupTimer->stop();
+    d->logic()->SetPivotCalibrationEnabled(false);
+    d->logic()->SetSpinCalibrationEnabled(true);
+    d->logic()->ClearSpinToolToReferenceMatrices();
     d->logic()->SetRecordingState(true);
     this->spinSamplingTimer->start();
   }
@@ -258,14 +309,15 @@ void qSlicerPivotCalibrationModuleWidget::onSpinSamplingTimeout()
   }
 }
 
-
 //-----------------------------------------------------------------------------
 void qSlicerPivotCalibrationModuleWidget::onPivotStop()
 {
   Q_D(qSlicerPivotCalibrationModuleWidget);
 
+  d->logic()->SetRecordingState(false);
+
   vtkMRMLLinearTransformNode* outputTransform = vtkMRMLLinearTransformNode::SafeDownCast(d->OutputComboBox->currentNode());
-  if (outputTransform==NULL)
+  if (outputTransform == NULL)
   {
     qCritical("qSlicerPivotCalibrationModuleWidget::onPivotStop failed: cannot save output transform");
     return;
@@ -273,9 +325,7 @@ void qSlicerPivotCalibrationModuleWidget::onPivotStop()
 
   vtkSmartPointer<vtkMatrix4x4> outputMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
   outputTransform->GetMatrixTransformToParent(outputMatrix);
-  d->logic()->SetToolTipToToolMatrix( outputMatrix ); // Sync logic's matrix with the scene's matrix
-
-  d->logic()->SetRecordingState(false);
+  d->logic()->SetToolTipToToolMatrix(outputMatrix); // Sync logic's matrix with the scene's matrix
 
   if (d->logic()->ComputePivotCalibration())
   {
@@ -296,14 +346,15 @@ void qSlicerPivotCalibrationModuleWidget::onPivotStop()
   d->logic()->ClearToolToReferenceMatrices();
 }
 
-
 //-----------------------------------------------------------------------------
 void qSlicerPivotCalibrationModuleWidget::onSpinStop()
 {
   Q_D(qSlicerPivotCalibrationModuleWidget);
 
+  d->logic()->SetRecordingState(false);
+
   vtkMRMLLinearTransformNode* outputTransform = vtkMRMLLinearTransformNode::SafeDownCast(d->OutputComboBox->currentNode());
-  if (outputTransform==NULL)
+  if (!outputTransform)
   {
     qCritical("qSlicerPivotCalibrationModuleWidget::onSpinStop failed: cannot save output transform");
     return;
@@ -311,9 +362,7 @@ void qSlicerPivotCalibrationModuleWidget::onSpinStop()
 
   vtkSmartPointer<vtkMatrix4x4> outputMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
   outputTransform->GetMatrixTransformToParent(outputMatrix);
-  d->logic()->SetToolTipToToolMatrix( outputMatrix ); // Sync logic's matrix with the scene's matrix
-
-  d->logic()->SetRecordingState(false);
+  d->logic()->SetToolTipToToolMatrix(outputMatrix); // Sync logic's matrix with the scene's matrix
 
   if (d->logic()->ComputeSpinCalibration(d->snapCheckBox->checkState() == Qt::Checked))
   {
@@ -336,7 +385,6 @@ void qSlicerPivotCalibrationModuleWidget::onSpinStop()
   d->logic()->ClearToolToReferenceMatrices();
 }
 
-
 //-----------------------------------------------------------------------------
 void qSlicerPivotCalibrationModuleWidget::setStartupDurationSec(double timeSec)
 {
@@ -349,12 +397,13 @@ void qSlicerPivotCalibrationModuleWidget::setSamplingDurationSec(double timeSec)
   this->samplingDurationSec = (int)timeSec;
 }
 
+//-----------------------------------------------------------------------------
 void qSlicerPivotCalibrationModuleWidget::onFlipButtonClicked()
 {
   Q_D(qSlicerPivotCalibrationModuleWidget);
 
   vtkMRMLLinearTransformNode* outputTransform = vtkMRMLLinearTransformNode::SafeDownCast(d->OutputComboBox->currentNode());
-  if (outputTransform==NULL)
+  if (!outputTransform)
   {
     qCritical("qSlicerPivotCalibrationModuleWidget::onSpinStop failed: cannot save output transform");
     return;
@@ -362,13 +411,249 @@ void qSlicerPivotCalibrationModuleWidget::onFlipButtonClicked()
 
   vtkSmartPointer<vtkMatrix4x4> outputMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
   outputTransform->GetMatrixTransformToParent(outputMatrix);
-  d->logic()->SetToolTipToToolMatrix( outputMatrix ); // Sync logic's matrix with the scene's matrix
+  d->logic()->SetToolTipToToolMatrix(outputMatrix); // Sync logic's matrix with the scene's matrix
 
   d->logic()->FlipShaftDirection();
 
-  d->logic()->GetToolTipToToolMatrix( outputMatrix );
+  d->logic()->GetToolTipToToolMatrix(outputMatrix);
   outputTransform->SetMatrixTransformToParent(outputMatrix);
 
   // Set the rmse label for the circle fitting rms error
   d->rmseLabel->setText("Flipped.");
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerPivotCalibrationModuleWidget::updateLogicFromWidget()
+{
+  Q_D(qSlicerPivotCalibrationModuleWidget);
+
+  // Pivot calibration settings
+  d->logic()->SetPivotAutoCalibrationStopWhenComplete(d->pivotAutoStopCheckBox->isChecked());
+
+  d->logic()->SetPivotAutoCalibrationTargetError(d->pivotTargetErrorSpinBox->value());
+  d->logic()->SetPivotAutoCalibrationTargetNumberOfPoints(d->pivotTargetPointSpinBox->value());
+  d->logic()->SetPivotMinimumOrientationDifferenceDegrees(d->pivotMinOrientationDifferenceSpinBox->value());
+
+  d->logic()->SetPivotPoseBucketSize(d->pivotBucketSizeSpinBox->value());
+  d->logic()->SetPivotMaximumNumberOfPoseBuckets(d->pivotMaxBucketSpinBox->value());
+  d->logic()->SetPivotMaximumPoseBucketError(d->pivotMaxBucketError->value());
+
+  d->logic()->SetPivotPositionDifferenceThresholdMm(d->pivotInputMinPositionDifferenceSpinBox->value());
+  d->logic()->SetPivotOrientationDifferenceThresholdDegrees(d->pivotInputOrientationDifferenceThresholdSpinBox->value());
+
+  // Spin calibration settings
+  d->logic()->SetSpinAutoCalibrationStopWhenComplete(d->spinAutoStopCheckBox->isChecked());
+
+  d->logic()->SetSpinAutoCalibrationTargetError(d->spinTargetErrorSpinBox->value());
+  d->logic()->SetSpinAutoCalibrationTargetNumberOfPoints(d->spinTargetPointSpinBox->value());
+  d->logic()->SetSpinMinimumOrientationDifferenceDegrees(d->spinMinOrientationDifferenceSpinBox->value());
+
+  d->logic()->SetSpinPoseBucketSize(d->spinBucketSizeSpinBox->value());
+  d->logic()->SetSpinMaximumNumberOfPoseBuckets(d->spinMaxBucketSpinBox->value());
+  d->logic()->SetSpinMaximumPoseBucketError(d->spinMaxBucketError->value());
+
+  d->logic()->SetSpinPositionDifferenceThresholdMm(d->spinInputMinPositionDifferenceSpinBox->value());
+  d->logic()->SetSpinOrientationDifferenceThresholdDegrees(d->spinInputOrientationDifferenceThresholdSpinBox->value());
+
+  if (d->tabWidget->currentWidget() == d->autoCalibrationTab)
+  {
+    // Enable calibration
+    bool pivotAutoCalibration = d->pivotAutoCalibrationButton->isChecked();
+    d->logic()->SetPivotCalibrationEnabled(pivotAutoCalibration);
+    d->logic()->SetPivotAutoCalibrationEnabled(pivotAutoCalibration);
+    bool spinAutoCalibration = d->spinAutoCalibrationButton->isChecked();
+    d->logic()->SetSpinCalibrationEnabled(spinAutoCalibration);
+    d->logic()->SetSpinAutoCalibrationEnabled(spinAutoCalibration);
+    d->logic()->SetRecordingState(d->logic()->GetPivotCalibrationEnabled() || d->logic()->GetSpinCalibrationEnabled());
+  }
+  else
+  {
+    d->logic()->SetPivotCalibrationEnabled(true);
+    d->logic()->SetPivotAutoCalibrationEnabled(false);
+    d->logic()->SetSpinCalibrationEnabled(true);
+    d->logic()->SetSpinAutoCalibrationEnabled(false);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerPivotCalibrationModuleWidget::updateWidgetFromLogic()
+{
+  Q_D(qSlicerPivotCalibrationModuleWidget);
+
+  bool calibrationRunning = d->logic()->GetRecordingState()
+    || this->pivotSamplingTimer->isActive()
+    || this->pivotStartupTimer->isActive()
+    || this->spinSamplingTimer->isActive()
+    || this->spinStartupTimer->isActive();
+
+  vtkMRMLNode* inputTransformNode = d->InputComboBox->currentNode();
+
+  d->tabWidget->tabBar()->setEnabled(!calibrationRunning);
+  d->startPivotButton->setEnabled(!calibrationRunning && inputTransformNode);
+  d->startSpinButton->setEnabled(!calibrationRunning && inputTransformNode);
+  d->startupTimerEdit->setEnabled(!calibrationRunning);
+  d->durationTimerEdit->setEnabled(!calibrationRunning);
+
+  bool wasBlocking = false;
+
+  // Pivot auto-calibration settings
+  wasBlocking = d->pivotAutoCalibrationButton->blockSignals(true);
+  d->pivotAutoCalibrationButton->setChecked(d->logic()->GetPivotCalibrationEnabled() && d->logic()->GetPivotAutoCalibrationEnabled());
+  d->pivotAutoCalibrationButton->blockSignals(wasBlocking);
+  wasBlocking = d->pivotAutoStopCheckBox->blockSignals(true);
+  d->pivotAutoStopCheckBox->setChecked(d->logic()->GetPivotAutoCalibrationStopWhenComplete());
+  d->pivotAutoStopCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->pivotTargetPointSpinBox->blockSignals(true);
+  d->pivotTargetPointSpinBox->setValue(d->logic()->GetPivotAutoCalibrationTargetNumberOfPoints());
+  d->pivotTargetPointSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->pivotTargetErrorSpinBox->blockSignals(true);
+  d->pivotTargetErrorSpinBox->setValue(d->logic()->GetPivotAutoCalibrationTargetError());
+  d->pivotTargetErrorSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->pivotMinOrientationDifferenceSpinBox->blockSignals(true);
+  d->pivotMinOrientationDifferenceSpinBox->setValue(d->logic()->GetPivotMinimumOrientationDifferenceDegrees());
+  d->pivotMinOrientationDifferenceSpinBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->pivotBucketSizeSpinBox->blockSignals(true);
+  d->pivotBucketSizeSpinBox->setValue(d->logic()->GetPivotPoseBucketSize());
+  d->pivotBucketSizeSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->pivotMaxBucketSpinBox->blockSignals(true);
+  d->pivotMaxBucketSpinBox->setValue(d->logic()->GetPivotMaximumNumberOfPoseBuckets());
+  d->pivotMaxBucketSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->pivotMaxBucketError->blockSignals(true);
+  d->pivotMaxBucketError->setValue(d->logic()->GetPivotMaximumPoseBucketError());
+  d->pivotMaxBucketError->blockSignals(wasBlocking);
+
+  wasBlocking = d->pivotInputOrientationDifferenceThresholdSpinBox->blockSignals(true);
+  d->pivotInputOrientationDifferenceThresholdSpinBox->setValue(d->logic()->GetPivotOrientationDifferenceThresholdDegrees());
+  d->pivotInputOrientationDifferenceThresholdSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->pivotInputMinPositionDifferenceSpinBox->blockSignals(true);
+  d->pivotInputMinPositionDifferenceSpinBox->setValue(d->logic()->GetPivotPositionDifferenceThresholdMm());
+  d->pivotInputMinPositionDifferenceSpinBox->blockSignals(wasBlocking);
+
+  int numberOfPivotPoses = d->logic()->GetPivotNumberOfPoses();
+  int targetNumberPivotPoses = d->logic()->GetPivotAutoCalibrationTargetNumberOfPoints();
+  d->pivotCalibrationProgressBar->setValue(100.0 * (double)numberOfPivotPoses / targetNumberPivotPoses);
+
+  // Spin auto-calibration settings
+  wasBlocking = d->spinAutoCalibrationButton->blockSignals(true);
+  d->spinAutoCalibrationButton->setChecked(d->logic()->GetSpinCalibrationEnabled() && d->logic()->GetSpinAutoCalibrationEnabled());
+  d->spinAutoCalibrationButton->blockSignals(wasBlocking);
+  wasBlocking = d->spinAutoStopCheckBox->blockSignals(true);
+  d->spinAutoStopCheckBox->setChecked(d->logic()->GetSpinAutoCalibrationStopWhenComplete());
+  d->spinAutoStopCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->spinTargetPointSpinBox->blockSignals(true);
+  d->spinTargetPointSpinBox->setValue(d->logic()->GetSpinAutoCalibrationTargetNumberOfPoints());
+  d->spinTargetPointSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->spinTargetErrorSpinBox->blockSignals(true);
+  d->spinTargetErrorSpinBox->setValue(d->logic()->GetSpinAutoCalibrationTargetError());
+  d->spinTargetErrorSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->spinMinOrientationDifferenceSpinBox->blockSignals(true);
+  d->spinMinOrientationDifferenceSpinBox->setValue(d->logic()->GetSpinMinimumOrientationDifferenceDegrees());
+  d->spinMinOrientationDifferenceSpinBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->spinBucketSizeSpinBox->blockSignals(true);
+  d->spinBucketSizeSpinBox->setValue(d->logic()->GetSpinPoseBucketSize());
+  d->spinBucketSizeSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->spinMaxBucketSpinBox->blockSignals(true);
+  d->spinMaxBucketSpinBox->setValue(d->logic()->GetSpinMaximumNumberOfPoseBuckets());
+  d->spinMaxBucketSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->spinMaxBucketError->blockSignals(true);
+  d->spinMaxBucketError->setValue(d->logic()->GetSpinMaximumPoseBucketError());
+  d->spinMaxBucketError->blockSignals(wasBlocking);
+
+  wasBlocking = d->spinInputOrientationDifferenceThresholdSpinBox->blockSignals(true);
+  d->spinInputOrientationDifferenceThresholdSpinBox->setValue(d->logic()->GetSpinOrientationDifferenceThresholdDegrees());
+  d->spinInputOrientationDifferenceThresholdSpinBox->blockSignals(wasBlocking);
+  wasBlocking = d->spinInputMinPositionDifferenceSpinBox->blockSignals(true);
+  d->spinInputMinPositionDifferenceSpinBox->setValue(d->logic()->GetSpinPositionDifferenceThresholdMm());
+  d->spinInputMinPositionDifferenceSpinBox->blockSignals(wasBlocking);
+
+  int numberOfSpinPoses = d->logic()->GetSpinNumberOfPoses();
+  int targetNumberSpinPoses = d->logic()->GetSpinAutoCalibrationTargetNumberOfPoints();
+  d->spinCalibrationProgressBar->setValue(100.0 * (double)numberOfSpinPoses / targetNumberSpinPoses);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerPivotCalibrationModuleWidget::onPivotAutoCalibrationComplete()
+{
+  Q_D(qSlicerPivotCalibrationModuleWidget);
+
+  vtkMRMLLinearTransformNode* outputTransform = vtkMRMLLinearTransformNode::SafeDownCast(d->OutputComboBox->currentNode());
+  if (!outputTransform)
+  {
+    return;
+  }
+
+  vtkSmartPointer<vtkMatrix4x4> outputMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+  outputTransform->GetMatrixTransformToParent(outputMatrix);
+  d->logic()->SetToolTipToToolMatrix(outputMatrix); // Sync logic's matrix with the scene's matrix
+
+  if (d->logic()->ComputePivotCalibration())
+  {
+    d->logic()->GetToolTipToToolMatrix(outputMatrix);
+    outputTransform->SetMatrixTransformToParent(outputMatrix);
+    std::stringstream ss;
+    ss << d->logic()->GetPivotRMSE();
+    d->rmseLabel->setText(ss.str().c_str());
+  }
+  else
+  {
+    qWarning() << "qSlicerPivotCalibrationModuleWidget::onPivotStop failed: ComputePivotCalibration returned with error: " << d->logic()->GetErrorText().c_str();
+    std::string fullMessage = std::string("Pivot calibration failed: ") + d->logic()->GetErrorText();
+    d->CountdownLabel->setText(fullMessage.c_str());
+    d->rmseLabel->setText("N/A");
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerPivotCalibrationModuleWidget::onSpinAutoCalibrationComplete()
+{
+  Q_D(qSlicerPivotCalibrationModuleWidget);
+
+  vtkMRMLLinearTransformNode* outputTransform = vtkMRMLLinearTransformNode::SafeDownCast(d->OutputComboBox->currentNode());
+  if (!outputTransform)
+  {
+    qCritical("qSlicerPivotCalibrationModuleWidget::onSpinStop failed: cannot save output transform");
+    return;
+  }
+
+  vtkSmartPointer<vtkMatrix4x4> outputMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+  outputTransform->GetMatrixTransformToParent(outputMatrix);
+  d->logic()->SetToolTipToToolMatrix(outputMatrix); // Sync logic's matrix with the scene's matrix
+
+  if (d->logic()->ComputeSpinCalibration(d->snapCheckBox->checkState() == Qt::Checked))
+  {
+    d->logic()->GetToolTipToToolMatrix(outputMatrix);
+    outputTransform->SetMatrixTransformToParent(outputMatrix);
+
+    // Set the rmse label for the circle fitting rms error
+    std::stringstream ss;
+    ss << d->logic()->GetSpinRMSE();
+    d->rmseLabel->setText(ss.str().c_str());
+  }
+  else
+  {
+    qWarning() << "qSlicerPivotCalibrationModuleWidget::onSpinStop failed: ComputeSpinCalibration returned with error: " << d->logic()->GetErrorText().c_str();
+    std::string fullMessage = std::string("Spin calibration failed: ") + d->logic()->GetErrorText();
+    d->CountdownLabel->setText(fullMessage.c_str());
+    d->rmseLabel->setText("N/A");
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerPivotCalibrationModuleWidget::onPivotResetButtonClicked()
+{
+  Q_D(qSlicerPivotCalibrationModuleWidget);
+  d->logic()->ClearPivotToolToReferenceMatrices();
+  this->updateWidgetFromLogic();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerPivotCalibrationModuleWidget::onSpinResetButtonClicked()
+{
+  Q_D(qSlicerPivotCalibrationModuleWidget);
+  d->logic()->ClearSpinToolToReferenceMatrices();
+  this->updateWidgetFromLogic();
 }

--- a/PivotCalibration/qSlicerPivotCalibrationModuleWidget.h
+++ b/PivotCalibration/qSlicerPivotCalibrationModuleWidget.h
@@ -39,9 +39,9 @@ class Q_SLICER_QTMODULES_PIVOTCALIBRATION_EXPORT qSlicerPivotCalibrationModuleWi
 
 public:
   typedef qSlicerAbstractModuleWidget Superclass;
-  qSlicerPivotCalibrationModuleWidget(QWidget *parent=0);
+  qSlicerPivotCalibrationModuleWidget(QWidget* parent = 0);
   virtual ~qSlicerPivotCalibrationModuleWidget();
-  
+
   virtual void enter();
 
 protected slots:
@@ -52,35 +52,43 @@ protected slots:
   void onSpinStop();
 
   void onFlipButtonClicked();
-  
+
   void setStartupDurationSec(double);
   void setSamplingDurationSec(double);
-  
+
   void onPivotStartupTimeout();
   void onPivotSamplingTimeout();
   void onSpinStartupTimeout();
   void onSpinSamplingTimeout();
-  
+
+  void updateLogicFromWidget();
+  void updateWidgetFromLogic();
+
+  void onPivotResetButtonClicked();
+  void onSpinResetButtonClicked();
+
+  void onPivotAutoCalibrationComplete();
+  void onSpinAutoCalibrationComplete();
+
 protected:
   QScopedPointer<qSlicerPivotCalibrationModuleWidgetPrivate> d_ptr;
 
   virtual void setup();
-  
-  int startupDurationSec;
-  int samplingDurationSec;
-  
+
+  int startupDurationSec{ 5 };
+  int samplingDurationSec{ 5 };
+
   QTimer* pivotStartupTimer;
-  int pivotStartupRemainingTimerPeriodCount;
-  
+  int pivotStartupRemainingTimerPeriodCount{ 0 };
+
   QTimer* pivotSamplingTimer;
-  int pivotSamplingRemainingTimerPeriodCount;
+  int pivotSamplingRemainingTimerPeriodCount{ 0 };
 
   QTimer* spinStartupTimer;
-  int spinStartupRemainingTimerPeriodCount;
-  
-  QTimer* spinSamplingTimer;
-  int spinSamplingRemainingTimerPeriodCount;
+  int spinStartupRemainingTimerPeriodCount{ 0 };
 
+  QTimer* spinSamplingTimer;
+  int spinSamplingRemainingTimerPeriodCount{ 0 };
 
 private:
   Q_DECLARE_PRIVATE(qSlicerPivotCalibrationModuleWidget);


### PR DESCRIPTION
Adds widgets for changing pivot/spin auto calibration settings.
Also adds vtkSlicerPivotCalibrationLogic::PivotCalibrationEnabled/SpinCalibrationEnabled flags so that pivot/spin can be enabled/disabled separately.

Slight reorganization of the pivot calibration module layout to move the settings collapsible button below results.

Widget show below:
![image](https://user-images.githubusercontent.com/9222709/174671394-e80e7f6e-db7b-475f-a13b-25f22259ade9.png)
