### PR TITLE
ENH: Add QTableWidget to qSlicerPathExplorerModuleWidget

### DIFF
--- a/PathExplorer/qSlicerPathExplorerModuleWidget.cxx
+++ b/PathExplorer/qSlicerPathExplorerModuleWidget.cxx
@@ -18,6 +18,7 @@
 // Qt includes
 #include <QDebug>
 #include <QShortcut>
+#include <QTableWidget>
 
 // SlicerQt includes
 #include "qSlicerPathExplorerModuleWidget.h"


### PR DESCRIPTION
This change is related to Slicer/Slicer#6909, which fixes the inclusion of generated (and private) Qt `ui_*` files; this indirectly included some Qt headers, which naturally would be missing. This commit includes the `QTableWidget` that would be required upon merging of Slicer/Slicer#6909. This change works also with Slicer/Slicer#6909 not merged.