### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@ option(SLICERIGT_ENABLE_EXPERIMENTAL_MODULES "Enable building experimental modul
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "http://www.slicerigt.org")
+set(EXTENSION_HOMEPAGE "https://www.slicerigt.org")
 set(EXTENSION_CATEGORY "IGT")
 set(EXTENSION_CONTRIBUTORS "Tamas Ungi (Queen's University), Junichi Tokuda (Brigham and Women's Hospital), Andras Lasso (Queen's University), Isaiah Norton (Brigham and Women's Hospital), Matthew Holden (Queen's University), Laurent Chauvin (SNR), Atsushi Yamada (SNR), Franklin King (Queen's University), Jaime Garcia-Guevara (Queen's University), Amelie Meyer (Queen's University), Mikael Brudfors (UCL), Adam Rankin (Robarts Research Institute)")
 set(EXTENSION_DESCRIPTION "This extension contains modules that enable rapid prototyping of applications for image-guided interventions. Intended users should have real-time imaging and/or tracking hardware (e.g. tracked ultrasound) connected to 3D Slicer through OpenIGTLink network. Specific modules allow patient registration to the navigation coordinate system in 3D Slicer, and real-time update of tracked models and images." )
-set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/2/2b/SlicerIGTLogo.png" )
-set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/7/78/SlicerIGTScreenshot.png" )
+set(EXTENSION_ICONURL "https://www.slicer.org/slicerWiki/images/2/2b/SlicerIGTLogo.png" )
+set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/slicerWiki/images/7/78/SlicerIGTScreenshot.png" )
 set(EXTENSION_DEPENDS SlicerIGSIO)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.