### PR TITLE
fix: import i18n in Ultrasound class

### DIFF
--- a/Guidelet/GuideletLib/UltraSound.py
+++ b/Guidelet/GuideletLib/UltraSound.py
@@ -2,6 +2,7 @@ import os
 from __main__ import vtk, qt, ctk, slicer
 import logging
 import time
+from slicer.i18n import tr as _
 
 class UltraSound(object):
   DEFAULT_IMAGE_SIZE = [800, 600, 1]


### PR DESCRIPTION
An exception is raised when using the Guidelet because the new localization feature was missing an import for `_` in the Ultrasound.py. Fix by adding the respective import.